### PR TITLE
Added occupancy_pirOToUDelay state

### DIFF
--- a/lib/devstates.js
+++ b/lib/devstates.js
@@ -324,6 +324,17 @@ const states = {
         read: true,
         type: 'boolean',
     },
+    occupancy_pirOToUDelay: {
+        id: 'occupancy_pirOToUDelay',
+        prop: 'occupancy_pirOToUDelay',
+        name: 'Delay Occupied to Unoccupied',
+        icon: undefined,
+        role: 'variable',
+        write: true,
+        read: true,
+        type: 'number',
+        epname: 'ep2',
+    },
     no_motion: {
         id: 'no_motion',
         prop: 'occupancy',
@@ -1373,7 +1384,7 @@ const devices = [{
         vendor: 'Philips',
         models: ['SML001'],
         icon: 'img/sensor_philipshue.png',
-        states: [states.battery, states.occupancy, states.temperature, states.illuminance],
+        states: [states.battery, states.occupancy, states.occupancy_pirOToUDelay, states.temperature, states.illuminance],
     },
 
 

--- a/lib/devstates.js
+++ b/lib/devstates.js
@@ -325,15 +325,17 @@ const states = {
         type: 'boolean',
     },
     occupancy_pirOToUDelay: {
-        id: 'occupancy_pirOToUDelay',
-        prop: 'occupancy_pirOToUDelay',
+        // this is different from occupancy_timeout,
+        // is writable timeout (to device).
+        id: 'occupancy_timeout',
+        prop: 'occupancy_timeout',
         name: 'Delay Occupied to Unoccupied',
         icon: undefined,
         role: 'variable',
         write: true,
         read: true,
         type: 'number',
-        epname: 'ep2',
+        epname: 'ep2', // philips hue sml001
     },
     no_motion: {
         id: 'no_motion',


### PR DESCRIPTION
Depends on [https://github.com/Koenkk/zigbee-shepherd-converters/pull/185](https://github.com/Koenkk/zigbee-shepherd-converters/pull/185)

Added state to write occupancy_pirOToUDelay attribute. (tested for hue SML001)
This is sensors timeout between "last motion detected" and sensor reports "occupancy false".
