### PR TITLE
Use readAfter states for reading values after main changes

### DIFF
--- a/lib/devstates.js
+++ b/lib/devstates.js
@@ -985,51 +985,56 @@ const comb = {
             // and new value > 0
             if (value > 0) {
                 // turn on light first
-                if (disableQueue) {
-                   return [{
-                      stateDesc: states.state,
-                      value: true,
-                      //index: -1, // before main change
-                      //timeout: 0,
-                      index: 1, // after main change
-                      timeout: timeout,
-                  }];
-                } else{ 
-                  if (!options.state) {
-                      return [{
-                          stateDesc: states.state,
-                          value: true,
-                          //index: -1, // before main change
-                          //timeout: 0,
-                          index: 1, // after main change
-                          timeout: timeout,
-                      }];
-                  }
+                if (disableQueue || !options.state) {
+                    return [{
+                        stateDesc: states.state,
+                        value: true,
+                        //index: -1, // before main change
+                        //timeout: 0,
+                        index: 1, // after main change
+                        timeout: timeout,
+                    }];
                 }
-            } else {
+            } else if (disableQueue || options.state) {
                 // turn off light after transition time
-                if (disableQueue) {
-                  return [{
-                      stateDesc: states.state,
-                      value: false,
-                      index: 1, // after main change
-                      timeout: timeout,
-                  }];
-                } else {
-                  if (options.state) {
-                      return [{
-                          stateDesc: states.state,
-                          value: false,
-                          index: 1, // after main change
-                          timeout: timeout,
-                      }];
-                  }
-                }
+                return [{
+                    stateDesc: states.state,
+                    value: false,
+                    index: 1, // after main change
+                    timeout: timeout,
+                }];
             }
         }
     }
 };
 
+//return list of states to read after main change has been done
+const readAfter = {
+    brightness: (state, value, options) => {
+        // if state is brightness
+        if (state.id === states.brightness.id) {
+            const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+            const timeout = (hasTransitionTime ? options.transition_time : 0) * 1000;    
+            if (value > 0) {
+                if (!options.state) {
+                    // read if light is turned on
+                    return [{
+                        stateDesc: states.state,
+                        value: true,
+                        timeout: timeout,
+                    }];
+                }
+            } else if (options.state) { 
+                // read if light is turned off
+                return [{
+                    stateDesc: states.state,
+                    value: false,
+                    timeout: timeout,
+                }];
+            }
+        }
+    }
+};
 
 const lightStatesWithColortemp = [states.state, states.brightness, states.colortemp, states.transition_time];
 const lightStatesWithColor = [states.state, states.brightness, states.colortemp, states.color, states.transition_time];
@@ -1185,22 +1190,21 @@ const devices = [{
         models: ['PAR16 50 TW'],
         icon: 'img/lightify-par16.png',
         states: lightStatesWithColortemp,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
-                 
-   {
+    {
         vendor: 'OSRAM',
         models: ['PAR 16 50 RGBW - LIGHTIFY'],
         icon: 'img/lightify-par16.png',
         states: lightStatesWithColor,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
     {
         vendor: 'OSRAM',
         models: ['Classic B40 TW - LIGHTIFY'],
         icon: 'img/lightify-b40tw.png',
         states: lightStatesWithColortemp,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
     {
         vendor: 'OSRAM',
@@ -1213,58 +1217,56 @@ const devices = [{
         models: ['Classic A60 RGBW', 'CLA60 RGBW OSRAM'],
         icon: 'img/osram_a60_rgbw.png',
         states: lightStatesWithColor,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
-
     {
         vendor: 'OSRAM',
         models: ['LIGHTIFY A19 Tunable White', 'Classic A60 TW', 'CLA60 TW OSRAM'],
         icon: 'img/osram_lightify.png',
         states: lightStatesWithColortemp,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
     {
         vendor: 'OSRAM',
         models: ['Ceiling TW OSRAM'],
         icon: 'img/osram_ceiling_tw.png',
         states: lightStatesWithColortemp,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
-                 
     {
         vendor: 'OSRAM',
         models: ['Flex RGBW', 'LIGHTIFY Indoor Flex RGBW', 'LIGHTIFY Outdoor Flex RGBW'],
         icon: 'img/philips_hue_lst002.png',
         states: lightStatesWithColor,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
     {
         vendor: 'OSRAM',
         models: ['Gardenpole RGBW-Lightify', 'Gardenspot W'],
         icon: 'img/philips_hue_lst002.png',
         states: lightStatesWithColor,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
     {
         vendor: 'OSRAM',
         models: ['Classic A60 W clear - LIGHTIFY'],
         icon: 'img/osram_lightify.png',
         states: lightStates,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },
     {
         vendor: 'OSRAM',
         models: ['Surface Light TW'],
         icon: 'img/osram_surface_light_tw.png',
         states: lightStatesWithColortemp,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },    
     {
         vendor: 'OSRAM',
         models: ['Surface Light W �C LIGHTIFY'],
         icon: 'img/osram_surface_light_tw.png',
         states: lightStates,
-        linkedStates: [comb.brightnessAndState],
+        readAfterStates: [readAfter.brightness],
     },         
                  
     // Hue and Philips
@@ -1585,7 +1587,7 @@ const devices = [{
     },
     {
         vendor: 'Custom devices (DiY)',
-      	models: ['DNCKAT_S001'],
+        models: ['DNCKAT_S001'],
         icon: 'img/diy.png',
         // TODO: description, type, rssi
         states: [states.DNCKAT_state_1],

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -401,7 +401,7 @@ class ZigbeeController extends EventEmitter {
         if (type === 'functional') {
             device.functional(cid, cmd, zclData, callback_);
         } else if (type === 'foundation') {
-            device.foundation(cid, cmd, [zclData], callback_);
+            device.foundation(cid, cmd, zclData, callback_);
         } else {
             this.error(`Unknown zigbee publish type ${type}`);
         }

--- a/main.js
+++ b/main.js
@@ -492,7 +492,6 @@ function getLibData(obj) {
     const cmdType = 'foundation';	
     var zclData = obj.message.zclData;	
     const zclId = require('zcl-id');	
-    adapter.log.error(typeof zclData);	
     if (!Array.isArray(zclData)) {	
         // wrap object in array	
         zclData = [zclData];	

--- a/main.js
+++ b/main.js
@@ -737,7 +737,11 @@ function publishFromState(deviceId, modelId, stateKey, state, options) {
                         adapter.log.debug(`Read after timeout for cmd '${readAfterMessage.cmd}' is ${readAfterTimeout}`);
                         setTimeout(()=>{
                             adapter.log.debug(`publishFromState - readAfter: deviceId=${deviceId}, message=${safeJsonStringify(readAfterMessage)}`);
-                            zbControl.publishDisableQueue(deviceId, readAfterMessage.cid, readAfterMessage.cmd, readAfterMessage.zclData, readAfterEp, readAfterMessage.cmdType);
+                            try {	
+                                zbControl.publishDisableQueue(deviceId, readAfterMessage.cid, readAfterMessage.cmd, readAfterMessage.zclData, readAfterEp, readAfterMessage.cmdType);
+                            } catch (exception) {	
+                                adapter.log.error('publishFromState - readAfter failed: ${safeJsonStringify(exception)}');
+                            }
                         }, readAfterTimeout || 0);
                     }
                 });

--- a/main.js
+++ b/main.js
@@ -740,7 +740,7 @@ function publishFromState(deviceId, modelId, stateKey, state, options) {
                             try {	
                                 zbControl.publishDisableQueue(deviceId, readAfterMessage.cid, readAfterMessage.cmd, readAfterMessage.zclData, readAfterEp, readAfterMessage.cmdType);
                             } catch (exception) {	
-                                adapter.log.error('publishFromState - readAfter failed: ${safeJsonStringify(exception)}');
+                                adapter.log.error(`publishFromState - readAfter failed: ${safeJsonStringify(exception)}`);
                             }
                         }, readAfterTimeout || 0);
                     }

--- a/main.js
+++ b/main.js
@@ -736,11 +736,7 @@ function publishFromState(deviceId, modelId, stateKey, state, options) {
                         adapter.log.debug(`Read after timeout for cmd '${readAfterMessage.cmd}' is ${readAfterTimeout}`);
                         setTimeout(()=>{
                             adapter.log.debug(`publishFromState - readAfter: deviceId=${deviceId}, message=${safeJsonStringify(readAfterMessage)}`);
-                            try {	
-                                zbControl.publishDisableQueue(deviceId, readAfterMessage.cid, readAfterMessage.cmd, readAfterMessage.zclData, readAfterEp, readAfterMessage.cmdType);
-                            } catch (exception) {
-                                adapter.log.error(`publishFromState - readAfter failed: ${exception}`);
-                            }
+                            zbControl.publishDisableQueue(deviceId, readAfterMessage.cid, readAfterMessage.cmd, readAfterMessage.zclData, readAfterEp, readAfterMessage.cmdType);
                         }, readAfterTimeout || 0);
                     }
                 });

--- a/main.js
+++ b/main.js
@@ -739,8 +739,8 @@ function publishFromState(deviceId, modelId, stateKey, state, options) {
                             adapter.log.debug(`publishFromState - readAfter: deviceId=${deviceId}, message=${safeJsonStringify(readAfterMessage)}`);
                             try {	
                                 zbControl.publishDisableQueue(deviceId, readAfterMessage.cid, readAfterMessage.cmd, readAfterMessage.zclData, readAfterEp, readAfterMessage.cmdType);
-                            } catch (exception) {	
-                                adapter.log.error(`publishFromState - readAfter failed: ${safeJsonStringify(exception)}`);
+                            } catch (exception) {
+                                adapter.log.error(`publishFromState - readAfter failed: ${exception}`);
                             }
                         }, readAfterTimeout || 0);
                     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   	"queue": "*",
     "debug": "^3.1.0",
     "serialport": "^6.2.0",
-    "zigbee-shepherd": "https://github.com/kirovilya/zigbee-shepherd/tarball/dev",
+    "zigbee-shepherd": "git+https://github.com/kirovilya/zigbee-shepherd/tarball/dev/.git#bc2445dc0bb7a2a1d5b4a461c231e28d07f517e7",
     "zigbee-shepherd-converters": "7.0.10"
   },
   "description": "Zigbee devices",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   	"queue": "*",
     "debug": "^3.1.0",
     "serialport": "^6.2.0",
-    "zigbee-shepherd": "https://github.com/kirovilya/zigbee-shepherd",
+    "zigbee-shepherd": "https://github.com/kirovilya/zigbee-shepherd/tarball/dev",
     "zigbee-shepherd-converters": "7.0.10"
   },
   "description": "Zigbee devices",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   	"queue": "*",
     "debug": "^3.1.0",
     "serialport": "^6.2.0",
-    "zigbee-shepherd": "git+https://github.com/kirovilya/zigbee-shepherd/tarball/dev/.git#bc2445dc0bb7a2a1d5b4a461c231e28d07f517e7",
+    "zigbee-shepherd": "git+https://github.com/kirovilya/zigbee-shepherd/tarball/dev.git#bc2445dc0bb7a2a1d5b4a461c231e28d07f517e7",
     "zigbee-shepherd-converters": "7.0.10"
   },
   "description": "Zigbee devices",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   	"queue": "*",
     "debug": "^3.1.0",
     "serialport": "^6.2.0",
-    "zigbee-shepherd": "git+https://github.com/kirovilya/zigbee-shepherd/tarball/dev.git#bc2445dc0bb7a2a1d5b4a461c231e28d07f517e7",
+    "zigbee-shepherd": "git+https://github.com/Koenkk/zigbee-shepherd.git#ce52ac4131e2a505af6197b4a26d2b5360e4eb80",
     "zigbee-shepherd-converters": "7.0.10"
   },
   "description": "Zigbee devices",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   	"queue": "*",
     "debug": "^3.1.0",
     "serialport": "^6.2.0",
-    "zigbee-shepherd": "git+https://github.com/Koenkk/zigbee-shepherd.git#ce52ac4131e2a505af6197b4a26d2b5360e4eb80",
+    "zigbee-shepherd": "https://github.com/kirovilya/zigbee-shepherd",
     "zigbee-shepherd-converters": "7.0.10"
   },
   "description": "Zigbee devices",


### PR DESCRIPTION
Dropped linkedStates from OSRAM devices cause they were causing too much errors.
Instead read command are introduced, which are executed after level has been set to synchronize
state "state" with internal zigbee device state ON or OFF.