### PR TITLE
Fixed queue handling

### DIFF
--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -404,13 +404,13 @@ class ZigbeeController extends EventEmitter {
 
         this.debug(`Zigbee publish to '${deviceID}', ${cid} - cmd ${cmd} - payload ${JSON.stringify(zclData)} - cfg ${JSON.stringify(cfg)} - endpoint ${ep}`);
 
-        const callback_ = (error) => {
+        const callback_ = (error, resp) => {
             if (error) {
                 this.error(
                     `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
                     `failed with error ${error}`);
             }
-            if (callback) callback(error);
+            if (callback) callback(error, resp);
         };
         if (type === 'functional') {
             device.functional(cid, cmd, zclData, cfg, callback_);

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -371,6 +371,7 @@ class ZigbeeController extends EventEmitter {
                         `failed with error ${error}`);
                 }
                 if (callback) callback(error, resp);
+                queueCallback();
             };
             if (type === 'functional') {
                 device.functional(cid, cmd, zclData, cfg, callback_);
@@ -378,8 +379,8 @@ class ZigbeeController extends EventEmitter {
                 device.foundation(cid, cmd, zclData, cfg, callback_);
             } else {
                 this.error(`Unknown zigbee publish type ${type}`);
+                queueCallback();
             }
-            queueCallback();
         });
     }
     

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "debug": "^3.1.0",
     "serialport": "^6.2.0",
     "zigbee-shepherd": "https://github.com/kirovilya/zigbee-shepherd/tarball/dev",
-    "zigbee-shepherd-converters": "7.0.22"
+    "zigbee-shepherd-converters": "7.0.24"
   },
   "description": "Zigbee devices",
   "devDependencies": {


### PR DESCRIPTION
@kirovilya 
I'm not so familar with queues and callback and so on. I had an issue when queue is enabled, then the commands are processed at once.

In example I started 100 time the "color" request to a lamp. That leads to 100 calls, several errors and after 30 seconds several timeouts occured. Also my lamp did a hard reset with fallback to factor settings (which then contained an older firmware; which was on the lamp at manufacture date).
I then reset the lamp manually, updated a new firmware via OSRAM gateway and then paired it again with the zigbee stick.

Now I restarted the test with the fixed queue; then also some errors occured, but the lamp didn't reset itself. When a timeout occured then you can see that directly in the log, but then the queued commands are processed further on.

So I would like, if you could have a look into it, before merging this PR.