### PR TITLE
Device configuration

### DIFF
--- a/main.js
+++ b/main.js
@@ -797,27 +797,26 @@ function scheduleDeviceConfig(device, delay) {
     if (pendingDevConfigRun == null) {
         const configCall = () => {
             adapter.log.debug(`Pending device configs: `+JSON.stringify(pendingDevConfigs));
-            if (!pendingDevConfigs || pendingDevConfigs.length == 0) {
-                return;
-            }
-            pendingDevConfigs.forEach((ieeeAddr) => {
-                const devToConfig = zbControl.getDevice(ieeeAddr);
-                configureDevice(devToConfig, (ok, msg) => {
-                    if (ok) {
-                        if (msg !== false) { // false = no config needed
-                            adapter.log.info(`Successfully configured ${ieeeAddr}`);
+            if (pendingDevConfigs && pendingDevConfigs.length > 0) {
+                pendingDevConfigs.forEach((ieeeAddr) => {
+                    const devToConfig = zbControl.getDevice(ieeeAddr);
+                    configureDevice(devToConfig, (ok, msg) => {
+                        if (ok) {
+                            if (msg !== false) { // false = no config needed
+                                adapter.log.info(`Successfully configured ${ieeeAddr}`);
+                            }
+                            var index = pendingDevConfigs.indexOf(ieeeAddr);
+                            if (index > -1) {
+                                pendingDevConfigs.splice(index, 1);
+                            }
+                        } else {
+                            adapter.log.warn(`Failed to configure ${ieeeAddr} ` + devToConfig.modelId + `, try again in 300 sec`);
+                            scheduleDeviceConfig(devToConfig, 300 * 1000);
                         }
-                        var index = pendingDevConfigs.indexOf(ieeeAddr);
-                        if (index > -1) {
-                            pendingDevConfigs.splice(index, 1);
-                        }
-                    } else {
-                        adapter.log.warn(`Failed to configure ${ieeeAddr} ` + devToConfig.modelId + `, try again in 300 sec`);
-                        scheduleDeviceConfig(devToConfig);
-                    }
+                    });
                 });
-            });
-            if (pendingDevConfigRun.length == 0) {
+            }
+            if (pendingDevConfigs.length == 0) {
                 pendingDevConfigRun = null;
             }
             else {

--- a/main.js
+++ b/main.js
@@ -32,6 +32,9 @@ let devNum = 0;
 let zbControl;
 let adapter;
 
+let pendingDevConfigRun = null;
+let pendingDevConfigs = [];
+
 function startAdapter(options) {
     options = options || {};
     Object.assign(options, {
@@ -44,6 +47,9 @@ function startAdapter(options) {
                 if (zbControl) {
                     zbControl.stop();
                     zbControl = undefined;
+                }
+                if (pendingDevConfigRun != null) {
+                    clearTimeout(pendingDevConfigRun);
                 }
                 callback();
             } catch (e) {
@@ -519,9 +525,10 @@ function newDevice(id, msg) {
     if (dev) {
         adapter.log.info('new dev ' + dev.ieeeAddr + ' ' + dev.nwkAddr + ' ' + dev.modelId);
         logToPairing('New device joined ' + dev.ieeeAddr + ' model ' + dev.modelId, true);
-        updateDev(dev.ieeeAddr.substr(2), dev.modelId, dev.modelId, () =>
-            syncDevStates(dev)
-        );
+        updateDev(dev.ieeeAddr.substr(2), dev.modelId, dev.modelId, () => {
+            syncDevStates(dev);
+            scheduleDeviceConfig(dev);
+        });
     }
 }
 
@@ -754,7 +761,7 @@ function onReady() {
                     resolve();
                 });
             }));
-            configureDevice(device);
+            scheduleDeviceConfig(device);
         });
         Promise.all(chain);
     });
@@ -776,22 +783,63 @@ function getDeviceStartupLogMessage(device) {
         `${friendlyDevice.vendor} ${friendlyDevice.description} (${type})`;
 }
 
-function configureDevice(device) {
+function scheduleDeviceConfig(device, delay) {
+    const ieeeAddr = device.ieeeAddr;
+    
+    if (pendingDevConfigs.indexOf(ieeeAddr) !== -1) { // device is already scheduled
+        return;
+    }
+    adapter.log.debug(`Schedule device config for ${ieeeAddr}`);
+    pendingDevConfigs.push(ieeeAddr);
+    if (!delay) {
+        delay = 30 * 1000;
+    }
+    if (pendingDevConfigRun == null) {
+        const configCall = () => {
+            adapter.log.debug(`Pending device configs: `+JSON.stringify(pendingDevConfigs));
+            if (!pendingDevConfigs || pendingDevConfigs.length == 0) {
+                return;
+            }
+            pendingDevConfigs.forEach((ieeeAddr) => {
+                const devToConfig = zbControl.getDevice(ieeeAddr);
+                configureDevice(devToConfig, (ok, msg) => {
+                    if (ok) {
+                        if (msg !== false) { // false = no config needed
+                            adapter.log.info(`Successfully configured ${ieeeAddr}`);
+                        }
+                        var index = pendingDevConfigs.indexOf(ieeeAddr);
+                        if (index > -1) {
+                            pendingDevConfigs.splice(index, 1);
+                        }
+                    } else {
+                        adapter.log.warn(`Failed to configure ${ieeeAddr} ` + devToConfig.modelId + `, try again in 300 sec`);
+                        scheduleDeviceConfig(devToConfig);
+                    }
+                });
+            });
+            if (pendingDevConfigRun.length == 0) {
+                pendingDevConfigRun = null;
+            }
+            else {
+                pendingDevConfigRun = setTimeout(configCall, 300 * 1000);
+            }
+        };
+        pendingDevConfigRun = setTimeout(configCall, delay);
+    }
+}
+
+function configureDevice(device, callback) {
     // Configure reporting for this device.
     const ieeeAddr = device.ieeeAddr;
     if (ieeeAddr && device.modelId) {
         const mappedModel = deviceMapping.findByZigbeeModel(device.modelId);
 
         if (mappedModel && mappedModel.configure) {
-            mappedModel.configure(ieeeAddr, zbControl.shepherd, zbControl.getCoordinator(), (ok, msg) => {
-                if (ok) {
-                    adapter.log.info(`Successfully configured ${ieeeAddr}`);
-                } else {
-                    adapter.log.warn(`Failed to configure ${ieeeAddr} ` + device.modelId);
-                }
-            });
+            mappedModel.configure(ieeeAddr, zbControl.shepherd, zbControl.getCoordinator(), callback);
+            return;
         }
     }
+    callback(true, false); // device does not require configuration
 }
 
 function onLog(level, msg, data) {


### PR DESCRIPTION
As of now, devices got only configured (bind, reporting in shepherd-converter) right after adapter start. It it failed for a device for some reason (mesh not ready, too much network load,...), this device stayed without config. Same with newly paired devices, it needed an adapter restart to make them fully work.

Changes in this PR:
- if device config fails, it will be tried again every 5 minutes
- configuration scheduled for newly and re-joined devices
- first configuration starts 30 seconds after adapter start (may help a bit to reduce network load on adapter start)