### PR TITLE
Fixed tint remote onOff state

### DIFF
--- a/lib/devstates.js
+++ b/lib/devstates.js
@@ -1166,6 +1166,17 @@ const states = {
         type: 'boolean',
         getter: payload => (payload.action === 'brightness_down_hold') ? true : (payload.action === 'brightness_down_release') ? false : undefined,
     },
+    tint404011_onoff: {
+        id: 'state',
+        prop: 'action',
+        name: 'Switch event',
+        icon: undefined,
+        role: 'button',
+        write: false,
+        read: true,
+        type: 'boolean',
+        getter: payload => (payload.action === 'on') ? true : ((payload.action === 'off') ? false : undefined),
+    },
     tint404011_brightness_up_click: {
       id: 'brightness_up_click',
       prop: 'action',
@@ -2466,7 +2477,7 @@ const devices = [{
           states.tint404011_scene_bonfire, states.tint404011_scene_romance,
           states.tint404011_brightness_up_click, states.tint404011_brightness_down_click,
           states.tint404011_colortemp_read, states.tint404011_color_read,
-          states.rwl_state
+          states.tint404011_onoff
         ]
     },
     // Ninja Blocks


### PR DESCRIPTION
This fixes the tint remote (see #221) on/off not working due to the change made in #247. 
It is fixed by introducing a new state specifically for the tint remote.