### PR TITLE
Update devstates.js

### DIFF
--- a/lib/devstates.js
+++ b/lib/devstates.js
@@ -1990,7 +1990,7 @@ const states = {
         write: true,
         read: true,
         type: 'string',
-        getter: payload => (payload.lockState === 'lock') ? 'lock' : (payload.lockState === 'unlock') ? 'unlock' : undefined,
+        getter: payload => (payload.state === 'LOCK') ? 'locked' : (payload.state === 'UNLOCK') ? 'unlocked' : undefined,
     },
     DIYRUZ_buzzer: {
         id: 'buzzer',


### PR DESCRIPTION
Changed the getter of lock_state to get the status update for Danalock working.
The lock status is now displayed by value "unlocked" and "locked".
To perform an action enter "lock" or "unlock" as value.