### PR TITLE
Fix for install error if running zigbee-adapter is updated

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -308,6 +308,7 @@
         "type": "hardware",
         "materialize": true,
         "messagebox": true,
+        "stopBeforeUpdate": true,
         "dataFolder": "zigbee_%INSTANCE%"
     },
     "native": {


### PR DESCRIPTION
Fixes the problem

Error: EPERM: operation not permitted, unlink 'C:\ioBroker\[<folder>]\node_modules\iobroker.zigbee\node_modules.serialport.DELETE\build\Release\serialport.node'

when updating running zigbee-adapter with admin.