### PR TITLE
Added lint checks to travis runs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/*
+test/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": ["eslint:recommended", "google"],
+    "parserOptions": {
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "rules": {
+        "require-jsdoc": "off",
+        "indent": ["error", 4],
+        "no-prototype-builtins": "off",
+        "max-len": ["error", { "code": 140 }],
+        "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+        "camelcase": ["error", {"properties": "always"}]
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,6 @@ script:
   - 'npm run test:package'
   - 'npm run test:unit'
   - 'npm run test:integration'
+  - if [ "$TRAVIS_COMMIT_RANGE" != "" ]; then COMMIT_RANGE=$TRAVIS_COMMIT_RANGE; else COMMIT_RANGE="HEAD^..HEAD"; fi;
+    echo "Lint check of commit range $COMMIT_RANGE";
+    lint-diff $COMMIT_RANGE

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "chai": "^4.2.0",
     "gulp": "^4.0.0",
     "mocha": "^6.0.2",
-    "@iobroker/testing": "^1.1.10"
+    "@iobroker/testing": "^1.1.10",
+    "eslint": "*",
+    "eslint-config-google": "*",
+    "lint-diff": "*"
   },
   "homepage": "https://github.com/ioBroker/ioBroker.zigbee",
   "keywords": [


### PR DESCRIPTION
To maintain some code quality of PR's, we should have some lint checks, similar to shepherd-converter.

That implementation will check only changed lines. Else we would have lot's of errors on existing code.