### PR TITLE
fix map endpoints can not work issue

### DIFF
--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -180,8 +180,8 @@ class ZigbeeController extends EventEmitter {
                     const mapped = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
                     const endpoints = mapped && mapped.endpoint ? mapped.endpoint(device) : null;
                     let endpoint;
-                    if (endpoints && ep != undefined) {
-                        endpoint = device.getEndpoint(ep);
+                    if (endpoints && ep != undefined && endpoints[ep]) {
+                        endpoint = device.getEndpoint(endpoints[ep]);
                     } else if (endpoints && endpoints['default']) {
                         endpoint = device.getEndpoint(endpoints['default']);
                     } else {


### PR DESCRIPTION
device.getEndpoint need a number, but ep is a string.
Need map string ep to ep number firstly, then call device.getEndpoint

Without this patch, some device which has multiple writeable endpoints can not work.
For example lumi.relay.c2acn01

Signed-off-by: SchumyHao <schumyhaojl@126.com>