### PR TITLE
Device-Info page and Developer-Tab fixed

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -344,6 +344,17 @@
                                 "cfg": { "manufCode": 4107, "manufSpec": 1}}<br>
                                 (You may use selectors together with expert mode to get prepared JSON)</div>
                             </li>
+                            <li>
+                                <div class="collapsible-header">Configure reporting</div>
+                                <div class="collapsible-body">Example (Expert Mode):<br>
+                                <b>JSON:</b> { "devId": "zigbee.0.yourDevId",
+                                "ep": "2", "cid": "msTemperatureMeasurement", "cmd": "configReport", "cmdType": "foundation",<br>
+                                "zclData": [{<br>
+                                "attribute": "measuredValue", <br>"minimumReportInterval": 1, <br>"maximumReportInterval": 600,<br>
+                                "reportableChange": 1 }],<br>
+                                "cfg": null}
+                                </div>
+                            </li>
                             </ul>
                             </div>
                         </div>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -320,7 +320,7 @@
                                 <div class="collapsible-body"><b>Device:</b> SML001, <b>Endpoint:</b> 2,
                                 <b>ClusterId:</b> msOccupancySensing (1030), <b>Command Type: </b>Foundation,
                                 <b>Command:</b> write (2), <b>AttributeId:</b> 
-                                pirOToUDelay (16, type 33), <b>Value:</b> 55, <b>Type:</b> uint16 (33)<br>
+                                pirOToUDelay (16, type 33), <b>Value:</b> 55<br>
                                 => (You set the timeout until motion detector changes from occupied not unoccupied,
                                 test it be <b>reading</b> same attribute)
                                 </div>
@@ -338,13 +338,10 @@
                             </li>
                             <li>
                                 <div class="collapsible-header">Expert Mode</div>
-                                <div class="collapsible-body">This is an example for Hue Motion Detector.
-                                Some of it's attributes cannot be accessed the standard way.<br>
+                                <div class="collapsible-body">Example:<br>
                                 <b>JSON:</b> { "devId": "zigbee.0.yourDevId",
-                                "ep": "2", "cid": "1030", "cmd": "0", "cmdType": "foundation", "zclData": { "attrId": "48" },
-                                "cfg": { "manufCode": 4107, "manufSpec": 1}}<br> 
-                                => Read attribute 48. Note "cfg" section, if you try to read same attribute without cfg
-                                settings, the sensor will reply "unsupAttribute"!<br>
+                                "ep": "2", "cid": "msOccupancySensing", "cmd": "write", "cmdType": "foundation", "zclData": { "pirOToUDelay": 30 },
+                                "cfg": { "manufCode": 4107, "manufSpec": 1}}<br>
                                 (You may use selectors together with expert mode to get prepared JSON)</div>
                             </li>
                             </ul>
@@ -353,7 +350,7 @@
                     </div>
                     <div class="col s9">
                         <div class="row">
-                            <div class="input-field col s4">
+                            <div class="input-field col s8">
                                 <select id ="dev-selector">
                                 <option value="" disabled selected>Select a device</option>
                                 </select>
@@ -392,26 +389,20 @@
                                     <option value="" disabled selected>Select Attribute</option>
                                     </select>
                                     <label for="attrid-selector">Attribute Id</label>
+                                </div>
+                                <div class="col s8">
+                                    <div class="input-field col s5 offset-s1 admin-tooltip-icon" title="Check if your Command needs to submit a value. For example, cmd 'write' needs the value you want to write to your device.">
+                                        <label for="value-needed" style="pointer-events: auto;">
+                                        <!-- workaround input not clickable https://codepen.io/alexisdiel/pen/gxwPWj -->
+                                            <input style="pointer-events: none;" id="value-needed" type="checkbox" class="filled-in"/>
+                                            <span style="pointer-events: none;">Needs value</span>
+                                        </label>
+                                    </div>
+                                    <div class="input-field col s6 admin-tooltip-icon" title="The value to send to your device (use douple-quotes if a number is a string).">
+                                        <input id ="value-input" disabled placeholder="0">
+                                        <label for="value-input">Value</label>
+                                    </div>
                                 </div> 
-                            </div>
-                            <div class="row">
-                                <div class="input-field col s3 offset-s1 admin-tooltip-icon" title="Check if your Command needs to submit a value. For example, cmd 'write' needs the value you want to write to your device.">
-                                    <label for="value-needed" style="pointer-events: auto;">
-                                    <!-- workaround input not clickable https://codepen.io/alexisdiel/pen/gxwPWj -->
-                                        <input style="pointer-events: none;" id="value-needed" type="checkbox" class="filled-in"/>
-                                        <span style="pointer-events: none;">Needs value</span>
-                                    </label>
-                                </div>
-                                <div class="input-field col s4 admin-tooltip-icon" title="The value to send to your device.">
-                                    <input id ="value-input" disabled placeholder="0">
-                                    <label for="value-input">Value</label>
-                                </div>
-                                <div class="input-field col s4 admin-tooltip-icon" title="The data type of your value (String, Integer,...)">
-                                    <select id ="type-selector" disabled>
-                                    <option value="" disabled selected>Select Type</option>
-                                    </select>
-                                    <label for="type-selector">Type Id</label>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -94,32 +94,12 @@ class Developer {
             cmd = zcl.Utils.getCluster(cid).getCommand(obj.message.cmd);
         } else if (cmdType === 'foundation') {
             cmd = zcl.Utils.getGlobalCommand((obj.message.cmd));
-            if (!Array.isArray(zclData)) {
-                // wrap object in array
-                zclData = [zclData];
-            }
         } else {
             this.adapter.sendTo(obj.from, obj.command, {localErr: 'Invalid cmdType'}, obj.callback);
             return;
         }
-
         const cfg = obj.message.hasOwnProperty('cfg') ? obj.message.cfg : null;
 
-        for (let i = 0; i < zclData.length; i++) {
-            const zclItem = zclData[i];
-            zclData[i] = zclItem.attrId;
-            // convert string items to number if needed
-//             if (typeof zclItem.attrId == 'string') {
-//                 const intId = parseInt(zclItem.attrId);
-// //                zclData[i].attrId = !isNaN(intId) ? intId : zclId.attr(cid, zclItem.attrId).value;
-//                 zclData[i].attrId = !isNaN(intId) ? intId : zcl.Utils.getCluster(cid).getAttribute(zclItem.attrId);
-//             }
-//             if (typeof zclItem.dataType == 'string') {
-//                 const intType = parseInt(zclItem.dataType);
-// //                zclData[i].dataType = !isNaN(intType) ? intType : zclId.attr(cid, zclItem.dataType).value;
-//                 zclData[i].dataType = !isNaN(intType) ? intType : zcl.Utils.getCluster(cid).getAttribute(zclItem.attrId);
-//             }
-        }
         const publishTarget = this.zbController.getDevice(devId) ? devId : this.zbController.getGroup(parseInt(devId));
         if (!publishTarget) {
             this.adapter.sendTo(obj.from, obj.command, {localErr: 'Device or group ' + devId + ' not found!'}, obj.callback);
@@ -129,7 +109,7 @@ class Developer {
             this.adapter.sendTo(obj.from, obj.command, {localErr: 'Incomplete data (cid or cmd)'}, obj.callback);
             return;
         }
-        this.debug('Ready to send (ep: ' + ep + ', cid: ' + cid + ' cmd, ' + cmd + ' json' + JSON.stringify(cmd)+ ' zcl: ' + JSON.stringify(zclData) + ')');
+        this.debug(`Ready to send (ep: ${ep}, cid: ${cid}, cmd ${cmd.name}, zcl: ${JSON.stringify(zclData)})`);
 
         try {
             this.zbController.publish(publishTarget, cid, cmd.name, zclData, cfg, ep, cmdType, (err, msg) => {

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -61,12 +61,12 @@ class Developer {
             result.list = zcl.Cluster;
         } else if (key === 'attrIdList') {
             const cid = obj.message.cid;
-            result.list = zcl.Utils.getCluster(parseInt(cid)).attributes;
+            result.list = zcl.Utils.getCluster(cid).attributes;
         } else if (key === 'cmdListFoundation') {
             result.list = zcl.Foundation;
         } else if (key === 'cmdListFunctional') {
             result.list = null;
-            const cluster = zcl.Utils.getCluster(parseInt(obj.message.cid));
+            const cluster = zcl.Utils.getCluster(obj.message.cid);
             if (typeof cluster != 'undefined') {
                 const extraCmd = cluster.commands;
                 result.list = extraCmd;
@@ -86,12 +86,12 @@ class Developer {
         const zcl = ZigbeeHerdsman.Zcl;
         const devId = '0x' + obj.message.id.replace(this.adapter.namespace + '.', '');
         const ep = obj.message.ep ? parseInt(obj.message.ep) : null;
-        const cid = parseInt(obj.message.cid);
+        const cid = obj.message.cid;
         const cmdType = obj.message.cmdType;
         let cmd;
         let zclData = obj.message.zclData;
         if (cmdType === 'functional') {
-            cmd = zcl.Utils.getCluster(cid).getCommand(parseInt(obj.message.cmd));
+            cmd = zcl.Utils.getCluster(cid).getCommand(obj.message.cmd);
         } else if (cmdType === 'foundation') {
             cmd = zcl.Utils.getGlobalCommand((obj.message.cmd));
             if (!Array.isArray(zclData)) {
@@ -137,15 +137,15 @@ class Developer {
                 const result = {};
                 result.msg = msg;
                 if (err) {
-                    // err is an instance of Error class, it cannot be forwarded to sendTo, just get message (string)
-                    result.err = err.message;
+                    // err is an instance of Error class, it cannot be forwarded to sendTo, just get error code
+                    result.error = err.code;
                 }
                 this.adapter.sendTo(obj.from, obj.command, result, obj.callback);
             });
         } catch (exception) {
             // report exceptions
             // happens for example if user tries to send write command but did not provide value/type
-            // we dont want to check this errors ourselfs before publish, but let shepherd handle this
+            // we don't want to check this errors ourself before publish, but let shepherd handle this
             this.error('SendToZigbee failed! (' + exception + ')');
             this.adapter.sendTo(obj.from, obj.command, {err: exception}, obj.callback);
 

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -538,7 +538,12 @@ class ZigbeeController extends EventEmitter {
                         }
                     };
                 }
-                const result = await endpoint[cmd](cid, zclData, cfg);
+                let result;
+                if (cmd === 'configReport') {
+                    result = await endpoint.configureReporting(cid, zclData, cfg);
+                } else {
+                    result = await endpoint[cmd](cid, zclData, cfg);
+                }
                 if (callback) callback(undefined, result);
             } else {
                 cfg.disableDefaultResponse = false;

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -533,7 +533,7 @@ class ZigbeeController extends EventEmitter {
                 if (callback) callback(undefined, result);
             }
         } catch (error) {
-            if (callback) callback(undefined, `Failed to publish: ${safeJsonStringify(error.stack)}`);
+            if (callback) callback(error, `Failed to publish: ${error.message}`);
             this.error(`Failed to publish: ${safeJsonStringify(error.stack)}`);
         }
     }

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -523,13 +523,26 @@ class ZigbeeController extends EventEmitter {
 
             this.debug(`Zigbee publish to '${deviceID}', ${cid} - cmd ${cmd} - payload ${JSON.stringify(zclData)} - cfg ${JSON.stringify(cfg)} - endpoint ${ep}`);
 
+            if (cfg == null) {
+                cfg = {};
+            }
+
             if (type === 'foundation') {
-                const result = await endpoint[cmd](cid, zclData);
-                this.debug('endpoint read returned ' + JSON.stringify(result));
+                cfg.disableDefaultResponse = true;
+                if (cmd === 'read') {
+                    // needs to be iterateable (string[] | number [])
+                    zclData[Symbol.iterator] = function* () {
+                        var k;
+                        for (k in this) {
+                            yield k;
+                        }
+                    };
+                }
+                const result = await endpoint[cmd](cid, zclData, cfg);
                 if (callback) callback(undefined, result);
             } else {
+                cfg.disableDefaultResponse = false;
                 const result = await endpoint.command(cid, cmd, zclData, cfg);
-                this.debug('endpoint command returned ' + JSON.stringify(result));
                 if (callback) callback(undefined, result);
             }
         } catch (error) {


### PR DESCRIPTION
Adjusted device-card info page and DeveloperTab to herdsman changes. Both working again.

- Attribute-type input removed (auto-detected)
- Needs https://github.com/Koenkk/zigbee-herdsman/pull/114 for full functionality, but may be merged already (result log messages incomplete only)

(Great job guys! I was very hesitant to switch to herdsman, because with last shepherd version, my smarthome stuff was stable for the first time. But herdsman seems to work stable as well :-) Thanks!)