### PR TITLE
Meta.states and eurotronic_host_flags added

### DIFF
--- a/lib/devstates.js
+++ b/lib/devstates.js
@@ -13,6 +13,7 @@ const utils = require(__dirname + '/utils.js');
    type - type of value
    isEvent - sign of clearing the value after 300ms
    isOption - if state is internal setting, not to be sent to device
+   inOptions - if true, value of this state will be included in options argument of other states setter(Opt)
    getter - result of call is the value of state. if value is undefined - state not apply
    setter - result of call is the value for publish to zigbee
    setterOpt - result of call is the options for publish to zigbee
@@ -1938,6 +1939,7 @@ const states = {
         type: 'number',
     },
     SPBZ0001_system_mode: { //0x4008
+        // for compatibility only, bits accessible as own states via eurotronic_host_flags 
         // if trv_mode = 2
         // bit 1 = rotate display 180
         // bit 2 = boost (in combination with bit 0)
@@ -1962,6 +1964,81 @@ const states = {
         write: false,
         read: true,
         type: 'number',
+    },
+    SPBZ0001_window_open: {
+        id: 'window_open',
+        name: 'Window Open / Off',
+        prop: 'eurotronic_host_flags',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'boolean',
+        inOptions: true,
+        setter: (value, options) => { 
+            return {window_open: value}; 
+        },
+        setterOpt: (value, options) => {
+            // converter needs previous value -> clone options values and set window_open to original value
+            return {state: {eurotronic_host_flags: {...options, window_open: !value}}};
+        },
+        getter: payload => payload.eurotronic_host_flags.window_open,
+    },
+    SPBZ0001_boost: {
+        id: 'boost',
+        name: 'Boost Mode',
+        prop: 'eurotronic_host_flags',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'boolean',
+        inOptions: true,
+        setter: (value, options) => {
+            return {boost: value};
+        },
+        setterOpt: (value, options) => {
+            return {state: {eurotronic_host_flags: {...options, boost: !value}}};
+        },
+        getter: payload => payload.eurotronic_host_flags.boost,
+    },
+
+    SPBZ0001_child_protection: {
+        id: 'child_protection',
+        name: 'Child Protection',
+        prop: 'eurotronic_host_flags',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'boolean',
+        inOptions: true,
+        setter: (value, options) => {
+            return {child_protection: value};
+        },
+        setterOpt: (value, options) => {
+            return {state: {eurotronic_host_flags: {...options, child_protection: !value}}};
+        },
+        getter: payload => payload.eurotronic_host_flags.child_protection,
+    },
+    
+    SPBZ0001_mirror_display: {
+        id: 'mirror_display',
+        name: 'Mirror Display',
+        prop: 'eurotronic_host_flags',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'boolean',
+        inOptions: true,
+        setter: (value, options) => {
+            return {mirror_display: value};
+        },
+        setterOpt: (value, options) => {
+            return {state: {eurotronic_host_flags: {...options, mirror_display: !value}}};
+        },
+        getter: payload => payload.eurotronic_host_flags.mirror_display,
     },
 
     natgas_detected: {
@@ -3891,9 +3968,12 @@ const devices = [{
         icon: 'img/Eurotronic_Spirit_04.png',
         states: [states.battery,
         states.hvacThermostat_local_temp, states.hvacThermostat_local_temp_calibration,
+        states.hvacThermostat_occupied_heating_setpoint, states.hvacThermostat_unoccupied_heating_setpoint,
         states.SPBZ0001_current_heating_setpoint, states.SPBZ0001_error_status,
         states.SPZB0001_valve_position, states.SPBZ0001_auto_valve_position,
-        states.SPBZ0001_system_mode, states.SPBZ0001_trv_mode],
+        states.SPBZ0001_system_mode, states.SPBZ0001_trv_mode,
+        states.SPBZ0001_window_open, states.SPBZ0001_boost,
+        states.SPBZ0001_child_protection, states.SPBZ0001_mirror_display],
     },
     // Immax
     {

--- a/main.js
+++ b/main.js
@@ -240,6 +240,9 @@ class Zigbee extends utils.Adapter {
                 message: {[key]: preparedValue},
                 logger: this.log,
             };
+            if (preparedOptions.hasOwnProperty('state')) {
+                meta.state = preparedOptions.state;
+            }
             try {
                 const result = await converter.convertSet(target, key, preparedValue, meta);
                 this.log.debug(`convert result ${safeJsonStringify(result)}`);


### PR DESCRIPTION
**meta.states**:
Some converter require states object in meta argument (`converter.convertSet(target, key, preparedValue, meta)`)
(like [here](https://github.com/Koenkk/zigbee-herdsman-converters/blob/72619c327da0429b6916dc248df5e9c6a371a5ef/converters/toZigbee.js#L840)
`const currentHostFlags = meta.state.eurotronic_host_flags ? meta.state.eurotronic_host_flags : {}`)

Added
```
if (preparedOptions.hasOwnProperty('state')) {
    meta.state = preparedOptions.state;
}
```
so we can return whatever is needed in setterOpt.

**eurotronic_host_flags** 
Added newly available settings as states (already in selected herdsman-converter)
Also added missing setpoint states

_Ready to merge from my side_