### PR TITLE
Update devices.js

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -342,7 +342,7 @@ const devices = [
     },
     {
         vendor: 'OSRAM',
-        models: ['PAR 16 50 RGBW - LIGHTIFY'],
+        models: ['PAR 16 50 RGBW - LIGHTIFY','PAR16 RGBW Z3'],
         icon: 'img/lightify-par16.png',
         states: lightStatesWithColor,
         syncStates: [sync.brightness],


### PR DESCRIPTION
modify
models: ['PAR 16 50 RGBW - LIGHTIFY'], to read
models: ['PAR 16 50 RGBW - LIGHTIFY','PAR16 RGBW Z3'],
that 
PAR16 RGBW Z3 bulbs are recognized