### PR TITLE
Hornbach FLAIR LED

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1600,6 +1600,14 @@ const devices = [
         icon: 'img/livolo.png',
         states: [states.stateEp],
     },
+    // HORNBACH
+    {
+        vendor: 'HORNBACH',
+        models: ['VIYU-A60-806-RGBW-10011725'],
+        icon: 'img/flair_viyu_e27_rgbw.png',
+        states: lightStatesWithColor,
+        syncStates: [sync.brightness],
+    },
 ];
 
 const commonStates = [


### PR DESCRIPTION
Added Support for Hornbach FLAIR Viyu Smarte LED Lampe RGB E27

Please also add the following image to img:
![flair_viyu_e27_rgbw](https://user-images.githubusercontent.com/55540912/74087788-f0442d00-4a8f-11ea-86a2-559ad2c9ad33.png)
