### PR TITLE
Added missing raw button events for Philips Hue Smart Button ROM001

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -552,6 +552,7 @@ const devices = [
         icon: 'img/hue-smart-button.png',
         states: [
             states.button_action_on, states.button_action_off,
+            states.button_action_press, states.button_action_hold, states.button_action_release,
             states.button_action_skip_back, states.button_action_skip_forward, states.battery,
         ],
     },

--- a/lib/states.js
+++ b/lib/states.js
@@ -1853,7 +1853,42 @@ const states = {
         isEvent: true,
         getter: payload => (payload.action === 'skip_backward') ? true : undefined,
     },
-
+    button_action_press: {
+        id: 'button_press',
+        prop: 'action',
+        name: 'Button Press',
+        icon: undefined,
+        role: 'button',
+        write: false,
+        read: true,
+        type: 'boolean',
+        isEvent: false,
+        getter: payload => (payload.action === 'press') ? true : undefined,
+    },
+    button_action_hold: {
+        id: 'button_hold',
+        prop: 'action',
+        name: 'Button Hold',
+        icon: undefined,
+        role: 'button',
+        write: false,
+        read: true,
+        type: 'boolean',
+        isEvent: false,
+        getter: payload => (payload.action === 'hold') ? true : undefined,
+    },
+    button_action_release: {
+        id: 'button_release',
+        prop: 'action',
+        name: 'Button Release',
+        icon: undefined,
+        role: 'button',
+        write: false,
+        read: true,
+        type: 'boolean',
+        isEvent: false,
+        getter: payload => (payload.action === 'release') ? true : undefined,
+    },
 
     // hvac Thermostat cluster - generic states
     hvacThermostat_local_temp: {


### PR DESCRIPTION
This pull request adds three subsequent data points regarding the Philips Hue Smart Button ROM001 to the ioBroker object tree, without changing any of the existing data points:

* `button_press`: The Smart Button is pressed.
* `button_hold`: The Smart Button is still hold down. This event is repeated as long as the button is pressed.
* `button_release`: This event is emitted after each `button_press` event and immediately after releasing a "hold".

These raw events were not supported yet but are required to react to a fast series of button press events. If the button is pressed in a very fast series, no events are generated but only a final high-level action event "on" or "off" is emitted. Thus, it is not possible to rotate through a set of light scenes using very fast button presses, such as the Hue Bridge provides.

More information is available in my pull request "Added missing raw button events for Philips Hue Smart Button ROM001" [https://github.com/Koenkk/zigbee-herdsman-converters/pull/1154](https://github.com/Koenkk/zigbee-herdsman-converters/pull/1154). This pull request was accepted today and is part of release 12.0.75.

All three action events are explicitly defined as `isEvent: false` in file `states.js`. This allows the button to be pressed and released with a much faster rate than only once each 300ms. This is required to implement the behavior of the Hue bridge, where a fast series of button press events cycles through all available light scenes,

However, not being an "event" anymore (`isEvent: false`), there is nothing setting the state of the data point back from "true" to "false". Instead, the data point is always "true", and thus, can not be used for level-triggering anymore (such as provided by a 300ms "true" level). Instead, scripts must use edge-based triggering using "on update" triggers. This is the behavior also implemented and required for all Homematic-IP-based buttons and switches. All HmIP switches provide "PRESS" events that are always true, are updated on each event, and thus allow processing a very high rate of press events. It takes a moment to accept that events are always "true", but triggering on updates is really superior.

IMHO, the level-based event handling with "delayed state reset" makes not much sense and is in general inferior to edge-based triggering. As a proposal, I would like to see the other four existing action events of this Smart Button to be converted to edge-based triggering by changing the "isEvent" attribute to false. However, this changes the semantics for these existing data points and will break existing scripts of users who already use this Smart Button in ioBroker. Thus, I did not include that to this pull request, but would like to start a discussion about this. Such change to edge-based triggering are also the key to solve some unsolved issues with the Philips Hue Dimmer RWL021, but I'm aiming at this later in a different pull request / discussion.

The data points proposed for conversion to `isEvent: false` are:

* button_action_on
* button_action_off
* button_action_skip_forward
* button_action_skip_back

And again, this pull requests requires zigbee-herdsman-converters 12.0.75 for the three introduced data points to become updated.

Thanks,
Florian

