### PR TITLE
be sure to have native part on every object

### DIFF
--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -229,7 +229,7 @@ class StatesController extends EventEmitter {
 
                     // only change object when any common property has changed
                     if (hasChanges) {
-                        this.adapter.extendObject(id, {type: 'state', common: new_common}, () => {
+                        this.adapter.extendObject(id, {type: 'state', common: new_common, native: {} }, () => {
                             value !== undefined && this.adapter.setState(id, value, true);
                         });
                     } else if (value !== undefined) {


### PR DESCRIPTION
Native part is mandatory.
If objects do not exists, they will be created by extendObject, but extendObject will not add native part.

No native part creates some issues, for example with iot Adapter not usable and so on.
What makes issues worse: Admin adapter adds an empty "native"-Part in RAW editor, so the issue is hard to detect.