### PR TITLE
Fixed mapping of brightness ranges

### DIFF
--- a/lib/states.js
+++ b/lib/states.js
@@ -937,11 +937,13 @@ const states = {
         unit: '',
         min: 0,
         max: 100,
-        // transform from 0..100 to 0..254
         getter: payload => {
+            // transform from [0...254] to [0...100]
             if (payload.brightness) {
-                return Math.round(payload.brightness*100/254);
+                // perform linear mapping of range [1...254] to [1...100]
+                return (Math.round((payload.brightness - 1) * 99 / 253) + 1);
             } else {
+                // zero is zero
                 return payload.brightness;
             }
         },
@@ -957,18 +959,23 @@ const states = {
         unit: '',
         min: 0,
         max: 100,
-        // transform from 0..100 to 0..254
         getter: payload => {
+            // transform from [0...254] to [0...100]
             if (payload.brightness) {
-                return Math.round(payload.brightness * 100 / 254);
+                // perform linear mapping of range [1...254] to [1...100]
+                return (Math.round((payload.brightness - 1) * 99 / 253) + 1);
             } else {
+                // zero is zero
                 return payload.brightness;
             }
         },
         setter: (value, options) => {
+            // transform from [0...100] to [0...254]
             if (value) {
-                return Math.round(value * 254 / 100);
+                // perform linear mapping of range [1...100] to [1...254]
+                return (Math.round((value - 1) * 253 / 99) + 1);
             } else {
+                // zero is zero
                 return value;
             }
         },
@@ -976,9 +983,12 @@ const states = {
             const hasTransitionTime = options && options.hasOwnProperty('transition_time');
             const transitionTime = hasTransitionTime ? options.transition_time : 0;
             let preparedOptions = {...options, transition: transitionTime};
+            // transform from [0...100] to [0...254]
             if (value) {
-                preparedOptions.brightness = Math.round(value * 254 / 100);
+                // perform linear mapping of range [1...100] to [1...254]
+                preparedOptions.brightness = (Math.round((value - 1) * 253 / 99) + 1);
             } else {
+                // zero is zero
                 preparedOptions.brightness = 0;
             }
             return preparedOptions;
@@ -986,7 +996,14 @@ const states = {
         readResponse: (resp) => {
             const respObj = resp[0];
             if (respObj.status === 0 && respObj.attrData != undefined) {
-                return Math.round(respObj.attrData * 100 / 254);
+                // transform from [0...254] to [0...100]
+                if (respObj.attrData) {
+                    // perform linear mapping of range [1...254] to [1...100]
+                    return (Math.round((respObj.attrData - 1) * 99 / 253) + 1);
+                } else {
+                    // zero is zero
+                    return respObj.attrData;
+                }
             }
         },
     },
@@ -3333,18 +3350,23 @@ const states = {
         unit: '',
         min: 0,
         max: 100,
-        // transform from 0..100 to 0..254
         getter: payload => {
+            // transform from [0...254] to [0...100]
             if (payload.white_value) {
-                return Math.round(payload.white_value * 100 / 254);
+                // perform linear mapping of range [1...254] to [1...100]
+                return (Math.round((payload.white_value - 1) * 99 / 253) + 1);
             } else {
+                // zero is zero
                 return payload.white_value;
             }
         },
         setter: (value, options) => {
+            // transform from [0...100] to [0...254]
             if (value) {
-                return Math.round(value * 254 / 100);
+                // perform linear mapping of range [1...100] to [1...254]
+                return (Math.round((value - 1) * 253 / 99) + 1);
             } else {
+                // zero is zero
                 return value;
             }
         },
@@ -3352,6 +3374,14 @@ const states = {
             const hasTransitionTime = options && options.hasOwnProperty('transition_time');
             const transitionTime = hasTransitionTime ? options.transition_time : 0;
             let preparedOptions = {...options, transition: transitionTime};
+            // transform from [0...100] to [0...254]
+            if (value) {
+                // perform linear mapping of range [1...100] to [1...254]
+                preparedOptions.white_value = (Math.round((value - 1) * 253 / 99) + 1);
+            } else {
+                // zero is zero
+                preparedOptions.white_value = 0;
+            }
             return preparedOptions;
         },
     },
@@ -3423,18 +3453,23 @@ const states = {
         unit: '',
         min: 0,
         max: 100,
-        // transform from 0..100 to 0..254
         getter: payload => {
+            // transform from [0...254] to [0...100]
             if (payload.brightness) {
-                return Math.round(payload.brightness * 100 / 254);
+                // perform linear mapping of range [1...254] to [1...100]
+                return (Math.round((payload.brightness - 1) * 99 / 253) + 1);
             } else {
+                // zero is zero
                 return payload.brightness;
             }
         },
         setter: (value, options) => {
+            // transform from [0...100] to [0...254]
             if (value) {
-                return Math.round(value * 254 / 100);
+                // perform linear mapping of range [1...100] to [1...254]
+                return (Math.round((value - 1) * 253 / 99) + 1);
             } else {
+                // zero is zero
                 return value;
             }
         },
@@ -3442,9 +3477,12 @@ const states = {
             const hasTransitionTime = options && options.hasOwnProperty('transition_time');
             const transitionTime = hasTransitionTime ? options.transition_time : 0;
             let preparedOptions = {...options, transition: transitionTime, state: {white_value: -1}};
+            // transform from [0...100] to [0...254]
             if (value) {
-                preparedOptions.brightness = Math.round(value * 254 / 100);
+                // perform linear mapping of range [1...100] to [1...254]
+                preparedOptions.brightness = (Math.round((value - 1) * 253 / 99) + 1);
             } else {
+                // zero is zero
                 preparedOptions.brightness = 0;
             }
             return preparedOptions;


### PR DESCRIPTION
This pull request addresses [issue 600](https://github.com/ioBroker/ioBroker.zigbee/issues/600). It fixes the equations for mapping between adaptor brightness levels [0...100] and bulb brightness levels [0...254].

- An adaptor brightness level of "0" is converted into bulb brightness level "0"
- An adaptor brightness level of "1" is converted into bulb brightness level "1"
- An adaptor brightness level of "100" is converted into bulb brightness level "254"
- A bulb brightness level of "0" is converted into adaptor brightness level "0"
- A bulb brightness level of "1" is converted into adaptor brightness level "1"
- A bulb brightness level of "254" is converted into adaptor brightness level "100"


