### PR TITLE
correct typo for innr light and add Paulmann 500.48

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1128,7 +1128,7 @@ const devices = [
     },
     {
         vendor: 'Innr',
-        models: ['RS 248 T', 'RB 148 T'],
+        models: ['RB 248 T', 'RB 148 T'],
         icon: 'img/innr3.png',
         states: lightStatesWithColortemp,
         linkedStates: [comb.brightnessAndState],
@@ -1326,6 +1326,13 @@ const devices = [
         models: ['Switch Controller'],
         icon: 'img/dimmablelight.png',
         states: [states.state],
+    },
+    {
+        vendor: 'Paulmann',
+        models: ['500.48'],
+        icon: 'img/paulmann_rgbw_controller.png',
+        states: lightStates,
+        syncStates: [sync.brightness],
     },
     {
         vendor: 'Paulmann',


### PR DESCRIPTION
As innr RB 248-T bulbs and Paulmann 500.48 did not work as expected, I analyzed the problem and did the following:
- corrected typo for RB 248 T
- add missing device 500.48

Now both kinds of device work fine.