### PR TITLE
Make bindings work with RWL021

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1711,8 +1711,8 @@ function addBindingDialog() {
             bind_source = $('#bindingmodaledit').find('#bind_source option:selected').val(),
             bind_source_ep = $('#bindingmodaledit').find('#bind_source_ep option:selected').val(),
             bind_target = $('#bindingmodaledit').find('#bind_target option:selected').val(),
-            bind_target_ep = $('#bindingmodaledit').find('#bind_target_ep option:selected').val();
-        unbind_from_coordinator = $('#bindingmodaledit').find('#unbind_from_coordinator').prop('checked');
+            bind_target_ep = $('#bindingmodaledit').find('#bind_target_ep option:selected').val(),
+            unbind_from_coordinator = $('#bindingmodaledit').find('#unbind_from_coordinator').prop('checked');
         addBinding(bind_source, bind_source_ep, bind_target, bind_target_ep, unbind_from_coordinator);
     });
     prepareBindingDialog();
@@ -1763,7 +1763,7 @@ function editBindingDialog(bindObj) {
             bind_source = $('#bindingmodaledit').find('#bind_source option:selected').val(),
             bind_source_ep = $('#bindingmodaledit').find('#bind_source_ep option:selected').val(),
             bind_target = $('#bindingmodaledit').find('#bind_target option:selected').val(),
-            bind_target_ep = $('#bindingmodaledit').find('#bind_target_ep option:selected').val();
+            bind_target_ep = $('#bindingmodaledit').find('#bind_target_ep option:selected').val(),
             unbind_from_coordinator = $('#bindingmodaledit').find('#unbind_from_coordinator').prop('checked');
         editBinding(bindObj.id, bind_source, bind_source_ep, bind_target, bind_target_ep, unbind_from_coordinator);
     });

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -20,7 +20,7 @@ let devices = [],
     cidList;
 
 const savedSettings = [
-    'port', 'panID', 'channel', 'disableLed', 'countDown', 'groups', 'extPanID', 'precfgkey', 'transmitPower', 
+    'port', 'panID', 'channel', 'disableLed', 'countDown', 'groups', 'extPanID', 'precfgkey', 'transmitPower',
     'adapterType', 'debugHerdsman',
 ];
 
@@ -1709,7 +1709,8 @@ function addBindingDialog() {
             bind_source_ep = $('#bindingmodaledit').find('#bind_source_ep option:selected').val(),
             bind_target = $('#bindingmodaledit').find('#bind_target option:selected').val(),
             bind_target_ep = $('#bindingmodaledit').find('#bind_target_ep option:selected').val();
-        addBinding(bind_source, bind_source_ep, bind_target, bind_target_ep);
+        unbind_from_coordinator = $('#bindingmodaledit').find('#unbind_from_coordinator').prop('checked');
+        addBinding(bind_source, bind_source_ep, bind_target, bind_target_ep, unbind_from_coordinator);
     });
     prepareBindingDialog();
 
@@ -1717,12 +1718,13 @@ function addBindingDialog() {
     Materialize.updateTextFields();
 }
 
-function addBinding(bind_source, bind_source_ep, bind_target, bind_target_ep) {
+function addBinding(bind_source, bind_source_ep, bind_target, bind_target_ep, unbind_from_coordinator) {
     sendTo(namespace, 'addBinding', {
         bind_source: bind_source,
         bind_source_ep: bind_source_ep,
         bind_target: bind_target,
-        bind_target_ep: bind_target_ep
+        bind_target_ep: bind_target_ep,
+        unbind_from_coordinator
     }, function (msg) {
         if (msg) {
             if (msg.error) {
@@ -1733,13 +1735,14 @@ function addBinding(bind_source, bind_source_ep, bind_target, bind_target_ep) {
     });
 }
 
-function editBinding(bind_id, bind_source, bind_source_ep, bind_target, bind_target_ep) {
+function editBinding(bind_id, bind_source, bind_source_ep, bind_target, bind_target_ep, unbind_from_coordinator) {
     sendTo(namespace, 'editBinding', {
         id: bind_id,
         bind_source: bind_source,
         bind_source_ep: bind_source_ep,
         bind_target: bind_target,
-        bind_target_ep: bind_target_ep
+        bind_target_ep: bind_target_ep,
+        unbind_from_coordinator
     }, function (msg) {
         if (msg) {
             if (msg.error) {
@@ -1758,7 +1761,8 @@ function editBindingDialog(bindObj) {
             bind_source_ep = $('#bindingmodaledit').find('#bind_source_ep option:selected').val(),
             bind_target = $('#bindingmodaledit').find('#bind_target option:selected').val(),
             bind_target_ep = $('#bindingmodaledit').find('#bind_target_ep option:selected').val();
-        editBinding(bindObj.id, bind_source, bind_source_ep, bind_target, bind_target_ep);
+            unbind_from_coordinator = $('#bindingmodaledit').find('#unbind_from_coordinator').prop('checked');
+        editBinding(bindObj.id, bind_source, bind_source_ep, bind_target, bind_target_ep, unbind_from_coordinator);
     });
     prepareBindingDialog(bindObj);
     $('#bindingmodaledit').modal('open');
@@ -1893,7 +1897,7 @@ function genDevInfo(device) {
             }).join('');
         }
     };
-    const mappedInfo = (!mapped) ? '' : 
+    const mappedInfo = (!mapped) ? '' :
         `<div style="font-size: 0.9em">
             <ul>
                 ${genRow('model', mapped.model)}               
@@ -1904,7 +1908,7 @@ function genDevInfo(device) {
     let epInfo = '';
     for (const epind in dev._endpoints) {
         const ep = dev._endpoints[epind];
-        epInfo += 
+        epInfo +=
             `<div style="font-size: 0.9em" class="truncate">
                 <ul>
                     ${genRow('endpoint', ep.ID)}
@@ -1914,7 +1918,7 @@ function genDevInfo(device) {
                 </ul>
             </div>`;
     }
-    const info = 
+    const info =
         `<div class="col s12 m6 l6 xl6">
             ${mappedInfo}
             <div class="divider"></div>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1699,6 +1699,9 @@ function prepareBindingDialog(bindObj){
             }
         );
     }
+
+    const unbind_fom_coordinator = bindObj ? bindObj.unbind_from_coordinator : false;
+    $('#unbind_from_coordinator').prop('checked', unbind_fom_coordinator);
 }
 
 function addBindingDialog() {

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -265,7 +265,7 @@
                             <p>Pan ID is some simplified id (is used by Zigbee instead of ExtPanID wherever possible). This should be unique too.
                             Note: Zigbee network may choose a different Pan ID than you specified here in case it detects id conflicts.</p>
                         </div>
-                        
+
                     </div>
                     <div class="row">
                         <div class="input-field col s12 m6 l4">
@@ -345,7 +345,7 @@
                             and in <a href="https://www.nxp.com/docs/en/user-guide/JN-UG-3115.pdf" target="_blank">ZigBee Cluster Library</a>.
                             </p>
                             <p>Please contribute your discoveries (<a href="https://github.com/Koenkk/zigbee-herdsman-converters" target="_blank">
-                            zigbee-herdsman-converters</a>) to make it available for other user too. 
+                            zigbee-herdsman-converters</a>) to make it available for other user too.
                             </p>
                         </div>
                         <div class="col s8">
@@ -686,6 +686,12 @@
                             <select id="bind_target_ep" class="materialSelect">
                             </select>
                             <label for="bind_target_ep" class="translate">Target endpoint</label>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col s9 input-field">
+                            <input id="unbind_from_coordinator" type="checkbox" class="value" />
+                            <label class="translate" for="unbind_from_coordinator">Unbind remote from Coorinator (necessary for some remotes like HUE Dimme Switch)</label>
                         </div>
                     </div>
                 </div>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -691,7 +691,7 @@
                     <div class="row">
                         <div class="col s9 input-field">
                             <input id="unbind_from_coordinator" type="checkbox" class="value" />
-                            <label class="translate" for="unbind_from_coordinator">Unbind remote from Coorinator (necessary for some remotes like HUE Dimme Switch)</label>
+                            <label class="translate" for="unbind_from_coordinator">Unbind remote from Coorinator (necessary for some remotes like HUE Dimmer Switch)</label>
                         </div>
                     </div>
                 </div>

--- a/admin/words.js
+++ b/admin/words.js
@@ -33,4 +33,16 @@ systemDictionary = {
     "Yes": {                                         "en": "Yes",                                             "de": "Ja",                                              "ru": "Да",                                              "pt": "sim",                                             "nl": "Ja",                                              "fr": "Oui",                                             "it": "sì",                                              "es": "Sí",                                              "pl": "tak",                                             "zh-cn": "是"},
     "Zigbee adapter": {                              "en": "Zigbee adapter",                                  "de": "Zigbee-Adapter",                                  "ru": "Zigbee драйвер",                                  "pt": "Adaptador Zigbee",                                "nl": "Zigbee-adapter",                                  "fr": "Adaptateur Zigbee",                               "it": "Adattatore Zigbee",                               "es": "Adaptador zigbee",                                "pl": "Adapter Zigbee",                                  "zh-cn": "Zigbee适配器"},
     "transmitPower": {                               "en": "CC1352P and CC26X2R1 transmit Power",             "de": "CC1352P and CC26X2R1 Sendeleistung",              "ru": "CC1352P and CC26X2R1 Мощность передачи",          "pt": "CC1352P and CC26X2R1 Potência de transmissão",    "nl": "CC1352P and CC26X2R1 zendvermogen",               "fr": "CC1352P and CC26X2R1 Puissance de transmission",  "it": "CC1352P and CC26X2R1 trasmettere potenza",        "es": "CC1352P and CC26X2R1 transmitir potencia",        "pl": "CC1352P and CC26X2R1 Moc nadawania",              "zh-cn": "CC1352P ,CC26X2R1 发射功率"},
+    "Unbind remote from Coorinator (necessary for some remotes like HUE Dimmer Switch)": {
+        "en": "Unbind remote from Coorinator (necessary for some remotes like HUE Dimmer Switch)",
+        "de": "Entfernen Sie die Fernbedienung von Coorinator (erforderlich für einige Fernbedienungen wie HUE Dimmer Switch).",
+        "ru": "Отсоедините пульт от Coorinator (необходим для некоторых пультов, таких как HUE Dimmer Switch)",
+        "pt": "Desconecte o controle remoto do Coorinator (necessário para alguns controles remotos, como o HUE Dimmer Switch)",
+        "nl": "Ontkoppel afstandsbediening van Coorinator (noodzakelijk voor sommige afstandsbedieningen zoals HUE Dimmer Switch)",
+        "fr": "Dissocier la télécommande de Coorinator (nécessaire pour certaines télécommandes comme HUE Dimmer Switch)",
+        "it": "Sblocca il telecomando da Coorinator (necessario per alcuni telecomandi come HUE Dimmer Switch)",
+        "es": "Desvincule el control remoto del Coordinador (necesario para algunos controles remotos como HUE Dimmer Switch)",
+        "pl": "Odłącz pilota od Coorinatora (niezbędny do niektórych pilotów, takich jak HUE Dimmer Switch)",
+        "zh-cn": "从Coorinator取消绑定遥控器（对于某些遥控器，例如HUE Dimmer Switch，这是必需的）"
+    }
 };

--- a/admin/words.js
+++ b/admin/words.js
@@ -35,7 +35,7 @@ systemDictionary = {
     "transmitPower": {                               "en": "CC1352P and CC26X2R1 transmit Power",             "de": "CC1352P and CC26X2R1 Sendeleistung",              "ru": "CC1352P and CC26X2R1 Мощность передачи",          "pt": "CC1352P and CC26X2R1 Potência de transmissão",    "nl": "CC1352P and CC26X2R1 zendvermogen",               "fr": "CC1352P and CC26X2R1 Puissance de transmission",  "it": "CC1352P and CC26X2R1 trasmettere potenza",        "es": "CC1352P and CC26X2R1 transmitir potencia",        "pl": "CC1352P and CC26X2R1 Moc nadawania",              "zh-cn": "CC1352P ,CC26X2R1 发射功率"},
     "Unbind remote from Coorinator (necessary for some remotes like HUE Dimmer Switch)": {
         "en": "Unbind remote from Coorinator (necessary for some remotes like HUE Dimmer Switch)",
-        "de": "Entfernen Sie die Fernbedienung von Coorinator (erforderlich für einige Fernbedienungen wie HUE Dimmer Switch).",
+        "de": "Entkoppele die Fernbedienung vom Coorinator (erforderlich für einige Fernbedienungen wie HUE Dimmer Switch).",
         "ru": "Отсоедините пульт от Coorinator (необходим для некоторых пультов, таких как HUE Dimmer Switch)",
         "pt": "Desconecte o controle remoto do Coorinator (necessário para alguns controles remotos, como o HUE Dimmer Switch)",
         "nl": "Ontkoppel afstandsbediening van Coorinator (noodzakelijk voor sommige afstandsbedieningen zoals HUE Dimmer Switch)",

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -92,14 +92,19 @@ class Binding {
             let target = await this.zbController.resolveEntity(`0x${this.extractDeviceId(bind_target)}`, parseInt(bind_target_ep));
             this.debug(`target: ${safeJsonStringify(target)}`);
             if (!target) {
-                target = await this.zbController.resolveEntity(parseInt(bind_target));
-                this.debug(`Group target: ${safeJsonStringify(target)}`);           
+                if (bind_target === 'coordinator') {
+                    target = await this.zbController.resolveEntity(bind_target);
+                    this.debug(`Coordinator target: ${safeJsonStringify(target)}`);
+                } else {
+                    target = await this.zbController.resolveEntity(parseInt(bind_target));
+                    this.debug(`Group target: ${safeJsonStringify(target)}`);
+                }
             }
 
             if (!source || !target) {
                 this.error('Devices not found');
                 if (callback) callback({error: 'Devices not found'});
-                return;
+                return {error: 'Devices not found'};
             }
             const sourceName = source.name;
             const targetName = target.name;
@@ -117,36 +122,40 @@ class Binding {
             if (!found) {
                 this.debug(`No bind clusters`);
                 if (callback) callback({error: `No bind clusters`});
+                return {error: `No bind clusters`};
             } else {
-                this.zbController.delayAction(source.device, async () => {
-                    for (const cluster of clusters) {
-                        const targetValid = target.type === 'group' ||
-                            target.device.type === 'Coordinator' || target.endpoint.supportsInputCluster(cluster);
+                return new Promise((resolve, reject) => {
+                    this.zbController.delayAction(source.device, async () => {
+                        for (const cluster of clusters) {
+                            const targetValid = target.type === 'group' ||
+                                target.device.type === 'Coordinator' || target.endpoint.supportsInputCluster(cluster);
 
-                        if (source.endpoint.supportsOutputCluster(cluster) && targetValid) {
-                            this.debug(`${type}ing cluster '${cluster}' from '${sourceName}' to '${targetName}'`);
-                            try {
-                                const bindTarget = target.type === 'group' ? target.group : target.endpoint;
-                                if (type === 'bind') {
-                                    await source.endpoint.bind(cluster, bindTarget);
-                                } else {
-                                    await source.endpoint.unbind(cluster, bindTarget);
+                            if (source.endpoint.supportsOutputCluster(cluster) && targetValid) {
+                                this.debug(`${type}ing cluster '${cluster}' from '${sourceName}' to '${targetName}'`);
+                                try {
+                                    const bindTarget = target.type === 'group' ? target.group : target.endpoint;
+                                    if (type === 'bind') {
+                                        await source.endpoint.bind(cluster, bindTarget);
+                                    } else {
+                                        await source.endpoint.unbind(cluster, bindTarget);
+                                    }
+                                    this.info(
+                                        `Successfully ${type === 'bind' ? 'bound' : 'unbound'} cluster '${cluster}' from ` +
+                                        `'${sourceName}' to '${targetName}'`,
+                                    );
+                                } catch (error) {
+                                    this.error(
+                                        `Failed to ${type} cluster '${cluster}' from '${sourceName}' to ` +
+                                        `'${targetName}' (${error})`,
+                                    );
+                                    //if (callback) callback({error: `Failed to ${type} cluster '${cluster}' from '${sourceName}' to '${targetName}' (${error})`});
+                                    //reject({error: `Failed to ${type} cluster '${cluster}' from '${sourceName}' to '${targetName}' (${error})`})
                                 }
-                                this.info(
-                                    `Successfully ${type === 'bind' ? 'bound' : 'unbound'} cluster '${cluster}' from ` +
-                                    `'${sourceName}' to '${targetName}'`,
-                                );
-                                
-                            } catch (error) {
-                                this.error(
-                                    `Failed to ${type} cluster '${cluster}' from '${sourceName}' to ` +
-                                    `'${targetName}' (${error})`,
-                                );
-                                if (callback) callback({error: `Failed to ${type} cluster '${cluster}' from '${sourceName}' to '${targetName}' (${error})`});
                             }
                         }
-                    }
-                    if (callback) callback(undefined,id);
+                        if (callback) callback(undefined, id);
+                        resolve(id);
+                    });
                 });
             }
         } catch (error) {
@@ -161,6 +170,11 @@ class Binding {
                 bind_source_ep = params.bind_source_ep,
                 bind_target = params.bind_target,
                 bind_target_ep = params.bind_target_ep;
+
+            if (params.unbind_from_coordinator) {
+                await this.doBindUnbind('unbind', bind_source, bind_source_ep, 'coordinator', '1');
+            }
+
             this.doBindUnbind('bind', bind_source, bind_source_ep, bind_target, bind_target_ep, (err, id) => {
                 if (err) {
                     callback({error: err});
@@ -200,6 +214,14 @@ class Binding {
                         await this.addBinding(from, command, params, callback);
                     }
                 });
+            } else {
+                const type = params.unbind_from_coordinator ? 'unbind' : 'bind';
+                try {
+                    await this.doBindUnbind(type , bind_source, bind_source_ep, 'coordinator', '1');
+                    this.debug('Successfully ' + (type === 'bind' ? 'bound' : 'unbound') + ' Coordinator from ' + bind_source);
+                } catch (e) {
+                    this.error('Could not ' + type + ' Coordinator from ' + bind_source + ': ' + JSON.stringify(e));
+                }
             }
         } catch (error) {
             this.error(`Failed to editBinding ${error.stack}`);
@@ -226,7 +248,11 @@ class Binding {
                                 if (err) {
                                     callback({error: err});
                                 } else {
-                                    callback();
+                                    if (params.unbind_from_coordinator) {
+                                        this.doBindUnbind('bind', bind_source, bind_source_ep, 'coordinator', '1', callback);
+                                    } else {
+                                        callback();
+                                    }
                                 }
                             });
                         }

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -220,7 +220,7 @@ class ZigbeeController extends EventEmitter {
 
         if (typeof key === 'string') {
             if (key === 'coordinator') {
-                const coordinator = this.herdsman.getDevicesByType('Coordinator');
+                const coordinator = this.herdsman.getDevicesByType('Coordinator')[0];
                 return {
                     type: 'device',
                     device: coordinator,


### PR DESCRIPTION
RWL021 (Hue Dimmer Switch) needs to be unbound from Coordinator in order to work correctly with binding. If that is not done (before!) binding, it will go into a state where it will only show a red LED and never send any commands anywhere anymore and will not react to anything. Only reset & repair will help, then.
So I added an option to unbind a device from coordinator before adding the binding. 

This is how I got bingdings with this remote get to work in zigbee2mqtt (and there is an issue there describing that problem with the same switch, see https://github.com/Koenkk/zigbee2mqtt/issues/2100 for example.)

Of course, without the binding to the coordinator, the coordinator won't see the commands send and won't know the state of the bulb in the end. So we'd either need reporting (which not all devices support, correct?) or polling (which I do with a script now)