### PR TITLE
possibility to use iobroker logger in code of the converters, via meta.logger

### DIFF
--- a/main.js
+++ b/main.js
@@ -175,6 +175,8 @@ class Zigbee extends utils.Adapter {
               cluster = message.cluster,
               devId = device.ieeeAddr.substr(2),
               meta = {device: device};
+        //this assigment give possibility to use iobroker logger in code of the converters, via meta.logger
+        meta.logger = this.log;
         if (!mappedModel) {
             return;
         }


### PR DESCRIPTION
As initial example taken usage system logger inside the converters in 
`meta.logger.info('ZNCLDJ11LM ' + (opts.hand_open ? 'enabling' : 'disabling') + ' hand open');`
There is [current link](https://github.com/Koenkk/zigbee-herdsman-converters/blob/7b769ef58f3667fec6691c14b071932c92037eb5/converters/toZigbee.js#L1162).
As I can uderstand - it's work with z2m.
But - it can work with iobroker.zigbee too
At least it works witn fromZigbee converters for sure ...
For example:
`if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: recorded index ${index} with value ${value}`);`