### PR TITLE
add state of current load (A) for lumi.plug.mmeu01

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -248,7 +248,7 @@ const devices = [
         vendor: 'Xiaomi',
         models: ['lumi.plug.mmeu01'],
         icon: 'img/xiaomi_plug_eu.png',
-        states: [states.state, states.load_power, states.plug_voltage, states.plug_consumption, states.plug_temperature],
+        states: [states.state, states.load_power, states.plug_voltage, states.load_current, states.plug_consumption, states.plug_temperature],
     },
     {
         vendor: 'Xiaomi',

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -248,7 +248,9 @@ const devices = [
         vendor: 'Xiaomi',
         models: ['lumi.plug.mmeu01'],
         icon: 'img/xiaomi_plug_eu.png',
-        states: [states.state, states.load_power, states.plug_voltage, states.load_current, states.plug_consumption, states.plug_temperature],
+        states: [
+            states.state, states.load_power, states.plug_voltage, states.load_current, states.plug_consumption,
+            states.plug_temperature],
     },
     {
         vendor: 'Xiaomi',


### PR DESCRIPTION
Taking in account the approprite accepted [pull request](https://github.com/Koenkk/zigbee-herdsman-converters/pull/1318) to zigbee-herdsman-converters, we have possibility to show the additional state for lumi.plug.mmeu01 devices - i.e. tje load current in A.
![image](https://user-images.githubusercontent.com/66964358/84996108-83cfed80-b155-11ea-8c74-a1e93070d0d4.png)
