### PR TITLE
Fixed the mapping between bulb levels and adapter levels.

### DIFF
--- a/lib/states.js
+++ b/lib/states.js
@@ -1009,14 +1009,7 @@ const states = {
         min: 0,
         max: 100,
         getter: payload => {
-            // transform from [0...254] to [0...100]
-            if (payload.brightness) {
-                // perform linear mapping of range [1...254] to [1...100]
-                return (Math.round((payload.brightness - 1) * 99 / 253) + 1);
-            } else {
-                // zero is zero
-                return payload.brightness;
-            }
+            return utils.bulbLevelToAdapterLevel(payload.brightness);
         },
     },
     brightness: {
@@ -1031,50 +1024,22 @@ const states = {
         min: 0,
         max: 100,
         getter: payload => {
-            // transform from [0...254] to [0...100]
-            if (payload.brightness) {
-                // perform linear mapping of range [1...254] to [1...100]
-                return (Math.round((payload.brightness - 1) * 99 / 253) + 1);
-            } else {
-                // zero is zero
-                return payload.brightness;
-            }
+            return utils.bulbLevelToAdapterLevel(payload.brightness);
         },
         setter: (value, options) => {
-            // transform from [0...100] to [0...254]
-            if (value) {
-                // perform linear mapping of range [1...100] to [1...254]
-                return (Math.round((value - 1) * 253 / 99) + 1);
-            } else {
-                // zero is zero
-                return value;
-            }
+            return utils.adapterLevelToBulbLevel(value);
         },
         setterOpt: (value, options) => {
             const hasTransitionTime = options && options.hasOwnProperty('transition_time');
             const transitionTime = hasTransitionTime ? options.transition_time : 0;
             const preparedOptions = {...options, transition: transitionTime};
-            // transform from [0...100] to [0...254]
-            if (value) {
-                // perform linear mapping of range [1...100] to [1...254]
-                preparedOptions.brightness = (Math.round((value - 1) * 253 / 99) + 1);
-            } else {
-                // zero is zero
-                preparedOptions.brightness = 0;
-            }
+            preparedOptions.brightness = utils.adapterLevelToBulbLevel(value);
             return preparedOptions;
         },
         readResponse: (resp) => {
             const respObj = resp[0];
             if (respObj.status === 0 && respObj.attrData != undefined) {
-                // transform from [0...254] to [0...100]
-                if (respObj.attrData) {
-                    // perform linear mapping of range [1...254] to [1...100]
-                    return (Math.round((respObj.attrData - 1) * 99 / 253) + 1);
-                } else {
-                    // zero is zero
-                    return respObj.attrData;
-                }
+                return utils.bulbLevelToAdapterLevel(respObj.attrData);
             }
         },
     },
@@ -3434,37 +3399,16 @@ const states = {
         min: 0,
         max: 100,
         getter: payload => {
-            // transform from [0...254] to [0...100]
-            if (payload.white_value) {
-                // perform linear mapping of range [1...254] to [1...100]
-                return (Math.round((payload.white_value - 1) * 99 / 253) + 1);
-            } else {
-                // zero is zero
-                return payload.white_value;
-            }
+            return utils.bulbLevelToAdapterLevel(payload.white_value);
         },
         setter: (value, options) => {
-            // transform from [0...100] to [0...254]
-            if (value) {
-                // perform linear mapping of range [1...100] to [1...254]
-                return (Math.round((value - 1) * 253 / 99) + 1);
-            } else {
-                // zero is zero
-                return value;
-            }
+            return utils.adapterLevelToBulbLevel(value);
         },
         setterOpt: (value, options) => {
             const hasTransitionTime = options && options.hasOwnProperty('transition_time');
             const transitionTime = hasTransitionTime ? options.transition_time : 0;
             const preparedOptions = {...options, transition: transitionTime};
-            // transform from [0...100] to [0...254]
-            if (value) {
-                // perform linear mapping of range [1...100] to [1...254]
-                preparedOptions.white_value = (Math.round((value - 1) * 253 / 99) + 1);
-            } else {
-                // zero is zero
-                preparedOptions.white_value = 0;
-            }
+            preparedOptions.white_value = utils.adapterLevelToBulbLevel(value);
             return preparedOptions;
         },
     },
@@ -3537,37 +3481,16 @@ const states = {
         min: 0,
         max: 100,
         getter: payload => {
-            // transform from [0...254] to [0...100]
-            if (payload.brightness) {
-                // perform linear mapping of range [1...254] to [1...100]
-                return (Math.round((payload.brightness - 1) * 99 / 253) + 1);
-            } else {
-                // zero is zero
-                return payload.brightness;
-            }
+            return utils.bulbLevelToAdapterLevel(payload.brightness);
         },
         setter: (value, options) => {
-            // transform from [0...100] to [0...254]
-            if (value) {
-                // perform linear mapping of range [1...100] to [1...254]
-                return (Math.round((value - 1) * 253 / 99) + 1);
-            } else {
-                // zero is zero
-                return value;
-            }
+            return utils.adapterLevelToBulbLevel(value);
         },
         setterOpt: (value, options) => {
             const hasTransitionTime = options && options.hasOwnProperty('transition_time');
             const transitionTime = hasTransitionTime ? options.transition_time : 0;
             const preparedOptions = {...options, transition: transitionTime, state: {white_value: -1}};
-            // transform from [0...100] to [0...254]
-            if (value) {
-                // perform linear mapping of range [1...100] to [1...254]
-                preparedOptions.brightness = (Math.round((value - 1) * 253 / 99) + 1);
-            } else {
-                // zero is zero
-                preparedOptions.brightness = 0;
-            }
+            preparedOptions.brightness = utils.adapterLevelToBulbLevel(value);
             return preparedOptions;
         },
     },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ function bulbLevelToAdapterLevel(bulbLevel) {
         // Perform linear mapping of range [2...254] to [1...100]
         return (Math.round((bulbLevel - 2) * 99 / 252) + 1);
     } else {
-        // The bulb is considered off. Evel a bulb level of "1" is considered as off.
+        // The bulb is considered off. Even a bulb level of "1" is considered as off.
         return 0;
     } // else
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,54 @@
 
 const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
 
+/**
+ * Converts a bulb level of range [0...254] to an adapter level of range [0...100]
+ * @param {number} the bulb level of range [0...254]
+ * @returns {the calculated adapter level}
+ */
+function bulbLevelToAdapterLevel(bulbLevel) {
+    // Convert from bulb levels [0...254] to adapter levels [0...100]:
+    // - Bulb level 0 is a forbidden value according to the ZigBee spec "ZigBee Cluster Library
+    //   (for ZigBee 3.0) User Guide", but some bulbs (HUE) accept this value and interpret this
+    //   value as "switch the bulb off".
+    // - A bulb level of "1" is the "minimum possible level" which should mean "bulb off",
+    //   but there are bulbs that do not switch off (they need "0", some IKEA bulbs are affected).
+    // - No visible difference was seen between bulb level 1 and 2 on HUE LCT012 bulbs.
+    //
+    // Conclusion:
+    // - We map adapter level "0" to the (forbidden) bulb level "0" that seems to switch all
+    //   known bulbs.
+    // - Bulb level "1" is not used, but if received nevertheless, it is converted to
+    //   adapter level "0" (off).
+    // - Bulb level range [2...254] is linearly mapped to adapter level range [1...100].
+    if (bulbLevel >= 2) {
+        // Perform linear mapping of range [2...254] to [1...100]
+        return (Math.round((bulbLevel - 2) * 99 / 252) + 1);
+    } else {
+        // The bulb is considered off. Evel a bulb level of "1" is considered as off.
+        return 0;
+    } // else
+}
+
+/**
+ * Converts an adapter level of range [0...100] to a bulb level of range [0...254]
+ * @param {number} the adapter level of range [0...100]
+ * @returns {the calculated bulb level}
+ */
+function adapterLevelToBulbLevel(adapterLevel) {
+    // Convert from adapter levels [0...100] to bulb levels [0...254].
+    // This is the inverse of function bulbLevelToAdapterLevel().
+    // Please read the comments there regarding the rules applied here for mapping the values.
+    if (adapterLevel) {
+        // Perform linear mapping of range [1...100] to [2...254]
+        return (Math.round((adapterLevel - 1) * 252 / 99) + 2);
+    } else {
+        // Switch the bulb off. Some bulbs need "0" (IKEA), others "1" (HUE), and according to the
+        // ZigBee docs "1" is the "minimum possible level"... we choose "0" here which seems to work.
+        return 0;
+    } // else
+}
+
 function bytesArrayToWordArray(ba) {
     const wa = [];
     for (let i = 0; i < ba.length; i++) {
@@ -50,15 +98,17 @@ const forceEndDevice = flatten(
 const xiaomiManufacturerID = [4151, 4447];
 const ikeaTradfriManufacturerID = [4476];
 
-exports.secondsToMilliseconds = (seconds) => seconds * 1000;
-exports.bytesArrayToWordArray = bytesArrayToWordArray;
-exports.decimalToHex          = decimalToHex;
-exports.getZbId               = getZbId;
-exports.getAdId               = getAdId;
-exports.isRouter              = (device) => device.type === 'Router' && !forceEndDevice.includes(device.modelID);
-exports.isBatteryPowered      = (device) => device.powerSource && device.powerSource === 'Battery';
-exports.isXiaomiDevice        = (device) => {
+exports.secondsToMilliseconds   = (seconds) => seconds * 1000;
+exports.bulbLevelToAdapterLevel = bulbLevelToAdapterLevel;
+exports.adapterLevelToBulbLevel = adapterLevelToBulbLevel;
+exports.bytesArrayToWordArray   = bytesArrayToWordArray;
+exports.decimalToHex            = decimalToHex;
+exports.getZbId                 = getZbId;
+exports.getAdId                 = getAdId;
+exports.isRouter                = (device) => device.type === 'Router' && !forceEndDevice.includes(device.modelID);
+exports.isBatteryPowered        = (device) => device.powerSource && device.powerSource === 'Battery';
+exports.isXiaomiDevice          = (device) => {
     return device.modelID !== 'lumi.router' && xiaomiManufacturerID.includes(device.manufacturerID) &&
             (!device.manufacturerName || !device.manufacturerName.startsWith('Trust'));
 };
-exports.isIkeaTradfriDevice   = (device) => ikeaTradfriManufacturerID.includes(device.manufacturerID);
+exports.isIkeaTradfriDevice     = (device) => ikeaTradfriManufacturerID.includes(device.manufacturerID);


### PR DESCRIPTION
This pull request is a follow-up to [this bug](https://github.com/ioBroker/ioBroker.zigbee/issues/600). My first pull request made it into the repository but it seems that it was incomplete:

- Thanks to the research of "allofmex" we know now that there are certain "bulb levels" that are "forbidden values" according to the ZigBee specification.
- However, there seem to be IKEA bulbs that require a value of "0" to switch them off.
- The former pull request introduced a regression that HUE bulbs can not be dimmed down to adapter level "1" anymore; they switch off instead.

This pull requests changes the mapping of levels again:
- Bulb levels "0" and "1" (of 254) are both considered as "off", and to switch a bulb off, bulb level "0" is sent.
- Bulb levels [2...254] are mapped to adapter levels [1...100] using a linear transformation.
- I created two functions for this transformation and put them into file utils.js. This helped me to cut out some duplicated code while fixing this issue.

Regards,
Florian