### PR TITLE
Update with Blaupunkt blind controller

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -2316,6 +2316,14 @@ const devices = [
             states.temperature_alarm, states.humidity_alarm,
         ],
     },
+	
+    // Blaupunkt
+    {
+      models: ['SCM-S1'],
+      icon:  'img/Ikea_fyrtur.png',
+      states: [states.blind_position, states.blind_stop],
+    },
+
 ];
 
 const commonStates = [

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -2319,9 +2319,9 @@ const devices = [
 	
     // Blaupunkt
     {
-      models: ['SCM-S1'],
-      icon:  'img/Ikea_fyrtur.png',
-      states: [states.blind_position, states.blind_stop],
+        models: ['SCM-S1'],
+        icon: 'img/Ikea_fyrtur.png',
+        states: [states.blind_position, states.blind_stop],
     },
 
 ];


### PR DESCRIPTION
This adds the Blaupunkt blind/shutter controller according to #580 
It's already included in herdsman converters.
