### PR TITLE
Added action_group state to Paulmann remote control 500.67

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1500,7 +1500,7 @@ const devices = [
             states.brightness_move_down, states.brightness_move_down_size,
             states.enhanced_move_to_hue_and_saturation, states.enhanced_move_enhanced_hue,
             states.enhanced_move_hue, states.enhanced_move_saturation,
-            states.scene,
+            states.scene,states.action_group
         ],
     },
 

--- a/lib/states.js
+++ b/lib/states.js
@@ -136,6 +136,15 @@ const states = {
         isEvent: true,
         getter: payload => (payload.action === 'double') ? true : undefined,
     },
+    action_group: {
+        id: 'action_group',
+        prop: 'action_group',
+        name: 'Action group',
+        role: 'state',
+        write: false,
+        read: true,
+        type: 'number',
+    },
     triple_click: {
         id: 'triple_click',
         prop: 'click',


### PR DESCRIPTION
The current implementation for the Paulmann 500.67 remote control does not allow to distinguish between groups.  The remote control has three group keys which allows to control three different devices. The currently selected group key is provided with the "action_group" property on each command. 
My suggested change will provide a state "action_group" which has the value of this group, e.g. 1, 2 or 3.