### PR TITLE
Update devices.js

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1486,7 +1486,7 @@ const devices = [
         syncStates: [sync.brightness],
     },
     {
-        models: ['371000001','371000002'],
+        models: ['371000001'],
         icon: 'img/paulmann_spot.png',
         states: lightStatesWithColortemp,
         syncStates: [sync.brightness],
@@ -1509,7 +1509,7 @@ const devices = [
         syncStates: [sync.brightness],
     },
     {
-        models: ['798.09'],
+        models: ['798.09','371000002'],
         icon: 'img/Paulmann_79809.png',
         states: lightStatesWithColor,
         syncStates: [sync.brightness],


### PR DESCRIPTION
Zigbeemodell for Paulmann Amaris Panel - 371000002 was on the wrong definition (paulmann_spot)

see Issue https://github.com/ioBroker/ioBroker.zigbee/issues/784