### PR TITLE
Added battery state for Tradfri E1524/E1810

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1159,7 +1159,7 @@ const devices = [
         states: [
             states.E1524_toggle, states.E1524_hold,
             states.E1524_left_click, states.E1524_right_click, states.E1524_up_click, states.E1524_down_click,
-            states.E1524_left_button, states.E1524_right_button, states.E1524_up_button, states.E1524_down_button,
+            states.E1524_left_button, states.E1524_right_button, states.E1524_up_button, states.E1524_down_button, states.battery
         ],
     },
     {


### PR DESCRIPTION
Tested with E1524 and E1810. Some Devices showed the battery state immediately, Some had to reset and re paired. The states apeard after some hours