### PR TITLE
added alert siren for Bitron AV2010/24A

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1905,7 +1905,7 @@ const devices = [
     {
         models: ['AV2010/24A'],
         icon: 'img/bitron_AV2010_24A.png',
-        states: [states.heiman_batt_low, states.smoke_detected],
+        states: [states.heiman_batt_low, states.smoke_detected, states.bitron_execute_warning],
     },
     {
         models: ['AV2010/22'],

--- a/lib/states.js
+++ b/lib/states.js
@@ -771,6 +771,19 @@ const states = {
             return {mode: 'stop', strobe: true, duration: value};
         },
     },
+    bitron_execute_warning: { // for Biton AV2010/24A
+        id: 'execute_warning',
+        prop: 'warning',
+        name: 'Execute warning (input: duration in sec)',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'number',
+        setter: (value) => {
+            return {strobe: false, duration: value};
+        },
+    },
     shake: {
         id: 'shake',
         prop: 'action',


### PR DESCRIPTION
I got the alert siren for Bitron AV2010/24A working.

It could work for Bitron 902010/24 too, but I do not have this device so I cannot test this.

Should close #794