### PR TITLE
Add "interlock" capability to Xiaomi LLKZMK11LM

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -349,9 +349,14 @@ function showDevices() {
         //if (d.groups && d.info && d.info.device._type == "Router") {
             if (d.groups) {
                 devGroups[d._id] = d.groups;
-                d.groupNames = d.groups.map(item=>{
-                    return groups[item] || '';
-                }).join(', ');
+                if (typeof d.groups.map == "function") {
+                    d.groupNames = d.groups.map(item=>{
+                        return groups[item] || '';
+                    }).join(', ');
+                }
+                else {
+                    d.groupNames = "..";
+                }
             }
             const card = getCard(d);
             html += card;

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -41,13 +41,13 @@ const comb = {
         if (state.id === states.effect_json.id) {
             let effectjson = {}
             try {
-                if (options.hasOwnProperty("effect_speed")) 
+                if (options.hasOwnProperty("effect_speed"))
                     effectjson.speed = options.effect_speed;
-                if (options.hasOwnProperty("effect_type")) 
+                if (options.hasOwnProperty("effect_type"))
                     effectjson.effect = options.effect_type;
 
-                if (options.hasOwnProperty("effect_colors")) 
-                    effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);         
+                if (options.hasOwnProperty("effect_colors"))
+                    effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);
 //               effectjson = JSON.parse(value);
             }
             catch {
@@ -56,14 +56,14 @@ const comb = {
                     speed:10,
                     effect:"glow",
                 };
-                if (options.hasOwnProperty("effect_speed")) 
+                if (options.hasOwnProperty("effect_speed"))
                     effectjson.speed = options.effect_speed;
-                if (options.hasOwnProperty("effect_colors")) 
+                if (options.hasOwnProperty("effect_colors"))
                     effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);
-                if (options.hasOwnProperty("effect_type")) 
+                if (options.hasOwnProperty("effect_type"))
                     effectjson.effect = options.effect_type;
-                
-            }    
+
+            }
             return [{
                 stateDesc: states.effect_json,
                 value: JSON.stringify(effectjson),
@@ -570,7 +570,8 @@ const devices = [
     {
         models: ['LLKZMK11LM'],
         icon: 'img/lumi_relay.png',
-        states: [states.channel1_state, states.channel2_state, states.load_power, states.temperature],
+        states: [states.channel1_state, states.channel2_state, states.load_power,
+                 states.temperature, states.interlock],
     },
     {
         models: ['ZNCLDJ11LM'],
@@ -2373,26 +2374,26 @@ const devices = [
     },
     {
         models: ['HG06492A'],
-        icon: 'img/HG06492A.png', 
+        icon: 'img/HG06492A.png',
         states: lightStatesWithColortemp_mired,
         syncStates: [sync.brightness],
     },
     {
         models: ['14147206L'],
-        icon: 'img/14147206L.png', 
+        icon: 'img/14147206L.png',
         states: lightStatesWithColortemp_mired,
         syncStates: [sync.brightness],
     },
     {
         models: ['HG06106C'],
-        icon: 'img/HG06106C.png', 
-        states: lightStatesWithColor_mired, 
+        icon: 'img/HG06106C.png',
+        states: lightStatesWithColor_mired,
         syncStates: [sync.brightness],
     },
     {
         models: ['HG06104A'],
-        icon: 'img/HG06104A.png', 
-        states: lightStatesWithColor_mired, 
+        icon: 'img/HG06104A.png',
+        states: lightStatesWithColor_mired,
         syncStates: [sync.brightness],
     },
     // Zemismart
@@ -2786,11 +2787,11 @@ const devices = [
     {
     	models: ['HG06467'],
     	icon: 'img/HG06467.png',
-    	states: [states.brightness, states.color_hs, states.state, states.effect_json, 
-        states.effect_speed, states.effect_type, states.effect_colors, states.transition_time],  
+    	states: [states.brightness, states.color_hs, states.state, states.effect_json,
+        states.effect_speed, states.effect_type, states.effect_colors, states.transition_time],
     	linkedStates: [comb.brightnessAndState, comb.effectJson],
     },
-	
+
 ];
 
 const commonStates = [

--- a/lib/states.js
+++ b/lib/states.js
@@ -5732,8 +5732,17 @@ const states = {
         write: true,
         read: true,
         type: 'string',
-        states: 'blink:blink;breathe:breathe;okay:okay;channel_change:channel_change;finish_effect:finish_effect;stop_effect:stop_effect'      
-    },	
+        states: 'blink:blink;breathe:breathe;okay:okay;channel_change:channel_change;finish_effect:finish_effect;stop_effect:stop_effect'
+    },
+    interlock: {
+        id: 'interlock',
+        name: 'Interlock',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'boolean',
+    },
 
 };
 


### PR DESCRIPTION
- news state "interlock" as boolean
- used state in Xiaomi LLKZMK11LM (Response to Issue #887 
- fix device listing for devices with malformed groups

Note: Expose was evaluated and discarded - no expose available for "interlock" in the converters. No expose expected due to rarity of the functionality
