### PR TITLE
Fix for Tuya Thermostat TS0601

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -2278,8 +2278,7 @@ const devices = [
         models: ['TS0601_thermostat'],
         icon: 'img/tuya_TS0601.png',
         states: [
-            states.child_lock,
-            states.voltage,
+            states.heiman_batt_low,
             states.hvacThermostat_local_temp,
             states.hvacThermostat_local_temp_calibration,
             states.tuya_trv_target_temperature,
@@ -2290,10 +2289,10 @@ const devices = [
             states.tuya_trv_boost_time,
             states.tuya_trv_comfort_temp,
             states.tuya_trv_eco_temp,
-            states.tuya_trv_system_mode,
+            states.climate_preset,
+//            states.climate_system_mode, removed: Tuya Thermostat does not recognize any mode aside "auto" (asgothian)
             states.tuya_trv_force_mode,
-            states.tuya_trv_valve_position,
-            states.SPBZ0001_window_open
+            states.tuya_trv_valve_position
         ],
     },
     {

--- a/lib/states.js
+++ b/lib/states.js
@@ -3951,10 +3951,11 @@ const states = {
         prop: 'child_lock',
         icon: undefined,
         role: 'state',
-        write: false,
+        write: true,
         read: true,
         type: 'boolean',
         getter: payload => (payload.child_lock === 'LOCKED'),
+        setter: (value) => (value) ? 'LOCK': 'UNLOCK',
     },
     tuya_trv_window_detected: {
         id: 'window_detected',


### PR DESCRIPTION
moved to statedefs used in expose
fixed tuya_trv_lock state to be read/write and actually work
removed child_lock due to conflict with tuya_trv_lock
changed from states.voltage to heimann_batt_low