### PR TITLE
1.4.1

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -34,6 +34,10 @@ class Binding {
     debug(msg) {
         this.adapter.log.debug(msg);
     }
+    
+    warn(msg) {
+        this.adapter.log.warn(msg);
+    }
 
     /**
      * @param {ioBroker.Message} obj

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -86,7 +86,10 @@ class Binding {
     }
 
     getBindEp(ep) {
-        return parseInt(ep.split('_')[0]);
+        if (ep)
+            return parseInt(ep.split('_')[0]);
+        this.warn(`getBindEp called with illegal ep: ${safeJsonStringify(ep)}`);
+        return -1;
     }
 
     getBindCl(ep) {

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,0 +1,460 @@
+'use strict';
+
+
+const namedColors = {
+    mediumvioletred: {
+        rgb:  '#c71585',
+    },
+    deeppink:	{
+        rgb:  '#ff1493',
+    },
+    palevioletred:  {
+        rgb:  '#db7093',
+    },
+    hotpink:	{
+        rgb:  '#ff69b4',
+    },
+    lightpink:	{
+        rgb:  '#ffb6c1',
+    },
+    pink:	{
+        rgb:  '#ffc0cb',
+    },
+    darkred:	{
+        rgb:  '#8b0000',
+    },
+    red:	{
+        rgb:  '#ff0000',
+    },
+    firebrick:	{
+        rgb:  '#b22222',
+    },
+    crimson:	{
+        rgb:  '#dc143c',
+    },
+    indianred:	{
+        rgb:  '#cd5c5c',
+    },
+    lightcoral:	{
+        rgb:  '#f08080',
+    },
+    salmon:	{
+        rgb:  '#fa8072',
+    },
+    darksalmon:	{
+        rgb:  '#e9967a',
+    },
+    lightsalmon:	{
+        rgb:  '#ffa07a',
+    },
+    orangered:	{
+        rgb:  '#ff4500',
+    },
+    tomato:	{
+        rgb:  '#ff6347',
+    },
+    darkorange:	{
+        rgb:  '#ff8c00',
+    },
+    coral:	{
+        rgb:  '#ff7f50',
+    },
+    orange:	{
+        rgb:  '#ffa500',
+    },
+    darkkhaki:	{
+        rgb:  '#bdb76b',
+    },
+    gold:	{
+        rgb:  '#ffd700',
+    },
+    khaki:	{
+        rgb:  '#f0e68c',
+    },
+    peachpuff:	{
+        rgb:  '#ffdab9',
+    },
+    yellow:	{
+        rgb:  '#ffff00',
+    },
+    palegoldenrod:	{
+        rgb:  '#eee8aa',
+    },
+    moccasin:	{
+        rgb:  '#ffe4b5',
+    },
+    papayawhip:	{
+        rgb:  '#ffefd5',
+    },
+    lightgoldenrodyellow:	{
+        rgb:  '#fafad2',
+    },
+    lemonchiffon:	{
+        rgb:  '#fffacd',
+    },
+    lightyellow:	{
+        rgb:  '#ffffe0',
+    },
+    maroon:	{
+        rgb:  '#800000',
+    },
+    brown:	{
+        rgb:  '#a52a2a',
+    },
+    saddlebrown:	{
+        rgb:  '#8b4513',
+    },
+    sienna:	{
+        rgb:  '#a0522d',
+    },
+    chocolate:	{
+        rgb:  '#d2691e',
+    },
+    darkgoldenrod:	{
+        rgb:  '#b8860b',
+    },
+    peru:	{
+        rgb:  '#cd853f',
+    },
+    rosybrown:	{
+        rgb:  '#bc8f8f',
+    },
+    goldenrod:	{
+        rgb:  '#daa520',
+    },
+    sandybrown:	{
+        rgb:  '#f4a460',
+    },
+    tan:	{
+        rgb:  '#d2b48c',
+    },
+    burlywood:	{
+        rgb:  '#deb887',
+    },
+    wheat:	{
+        rgb:  '#f5deb3',
+    },
+    navajowhite:	{
+        rgb:  '#ffdead',
+    },
+    bisque:	{
+        rgb:  '#ffe4c4',
+    },
+    blanchedalmond:	{
+        rgb:  '#ffebcd',
+    },
+    cornsilk:	{
+        rgb:  '#fff8dc',
+    },
+    darkgreen:	{
+        rgb:  '#006400',
+    },
+    green:	{
+        rgb:  '#008000',
+    },
+    darkolivegreen:	{
+        rgb:  '#556b2f',
+    },
+    forestgreen:	{
+        rgb:  '#228b22',
+    },
+    seagreen:	{
+        rgb:  '#2e8b57',
+    },
+    olive:	{
+        rgb:  '#808000',
+    },
+    olivedrab:	{
+        rgb:  '#6b8e23',
+    },
+    mediumseagreen:	{
+        rgb:  '#3cb371',
+    },
+    limegreen:	{
+        rgb:  '#32cd32',
+    },
+    lime:	{
+        rgb:  '#00ff00',
+    },
+    springgreen:	{
+        rgb:  '#00ff7f',
+    },
+    mediumspringgreen:	{
+        rgb:  '#00fa9a',
+    },
+    darkseagreen:	{
+        rgb:  '#8fbc8f',
+    },
+    mediumaquamarine:	{
+        rgb:  '#66cdaa',
+    },
+    yellowgreen:	{
+        rgb:  '#9acd32',
+    },
+    lawngreen:	{
+        rgb:  '#7cfc00',
+    },
+    chartreuse:	{
+        rgb:  '#7fff00',
+    },
+    lightgreen:	{
+        rgb:  '#90ee90',
+    },
+    greenyellow:	{
+        rgb:  '#adff2f',
+    },
+    palegreen:	{
+        rgb:  '#98fb98',
+    },
+    teal:	{
+        rgb:  '#008080',
+    },
+    darkcyan:	{
+        rgb:  '#008b8b',
+    },
+    lightseagreen:	{
+        rgb:  '#20b2aa',
+    },
+    cadetblue:	{
+        rgb:  '#5f9ea0',
+    },
+    darkturquoise:	{
+        rgb:  '#00ced1',
+    },
+    mediumturquoise:	{
+        rgb:  '#48d1cc',
+    },
+    turquoise:	{
+        rgb:  '#40e0d0',
+    },
+    aqua:	{
+        rgb:  '#00ffff',
+    },
+    cyan:	{
+        rgb:  '#00ffff',
+    },
+    aquamarine:	{
+        rgb:  '#7fffd4',
+    },
+    paleturquoise:	{
+        rgb:  '#afeeee',
+    },
+    lightcyan:	{
+        rgb:  '#e0ffff',
+    },
+    navy:	{
+        rgb:  '#000080',
+    },
+    darkblue:	{
+        rgb:  '#00008b',
+    },
+    mediumblue:	{
+        rgb:  '#0000cd',
+    },
+    blue:	{
+        rgb:  '#0000ff',
+    },
+    midnightblue:	{
+        rgb:  '#191970',
+    },
+    royalblue:	{
+        rgb:  '#4169e1',
+    },
+    steelblue:	{
+        rgb:  '#4682b4',
+    },
+    dodgerblue:	{
+        rgb:  '#1e90ff',
+    },
+    deepskyblue:	{
+        rgb:  '#00bfff',
+    },
+    cornflowerblue:	{
+        rgb:  '#6495ed',
+    },
+    skyblue:	{
+        rgb:  '#87ceeb',
+    },
+    lightskyblue:	{
+        rgb:  '#87cefa',
+    },
+    lightsteelblue:	{
+        rgb:  '#b0c4de',
+    },
+    lightblue:	{
+        rgb:  '#add8e6',
+    },
+    powderblue:	{
+        rgb:  '#b0e0e6',
+    },
+    indigo:	{
+        rgb:  '#4b0082',
+    },
+    purple:	{
+        rgb:  '#800080',
+    },
+    darkmagenta:	{
+        rgb:  '#8b008b',
+    },
+    darkviolet:	{
+        rgb:  '#9400d3',
+    },
+    darkslateblue:	{
+        rgb:  '#483d8b',
+    },
+    blueviolet:	{
+        rgb:  '#8a2be2',
+    },
+    darkorchid:	{
+        rgb:  '#9932cc',
+    },
+    fuchsia:	{
+        rgb:  '#ff00ff',
+    },
+    magenta:	{
+        rgb:  '#ff00ff',
+    },
+    slateblue:	{
+        rgb:  '#6a5acd',
+    },
+    mediumslateblue:	{
+        rgb:  '#7b68ee',
+    },
+    mediumorchid:	{
+        rgb:  '#ba55d3',
+    },
+    mediumpurple:	{
+        rgb:  '#9370db',
+    },
+    orchid:	{
+        rgb:  '#da70d6',
+    },
+    violet:	{
+        rgb:  '#ee82ee',
+    },
+    plum:	{
+        rgb:  '#dda0dd',
+    },
+    thistle:	{
+        rgb:  '#d8bfd8',
+    },
+    lavender:	{
+        rgb:  '#e6e6fa',
+    },
+    mistyrose:	{
+        rgb:  '#ffe4e1',
+    },
+    antiquewhite:	{
+        rgb:  '#faebd7',
+    },
+    linen:	{
+        rgb:  '#faf0e6',
+    },
+    beige:	{
+        rgb:  '#f5f5dc',
+    },
+    whitesmoke:	{
+        rgb:  '#f5f5f5',
+    },
+    lavenderblush:	{
+        rgb:  '#fff0f5',
+    },
+    oldlace:	{
+        rgb:  '#fdf5e6',
+    },
+    aliceblue:	{
+        rgb:  '#f0f8ff',
+    },
+    seashell:	{
+        rgb:  '#fff5ee',
+    },
+    ghostwhite:	{
+        rgb:  '#f8f8ff',
+    },
+    honeydew:	{
+        rgb:  '#f0fff0',
+    },
+    floralwhite:	{
+        rgb:  '#fffaf0',
+    },
+    azure:	{
+        rgb:  '#f0ffff',
+    },
+    mintcream:	{
+        rgb:  '#f5fffa',
+    },
+    snow:	{
+        rgb:  '#fffafa',
+    },
+    ivory:	{
+        rgb:  '#fffff0',
+    },
+    white:	{
+        rgb:  '#ffffff',
+    },
+    black:	{
+        rgb:  '#000000',
+    },
+    darkslategray:	{
+        rgb:  '#2f4f4f',
+    },
+    dimgray:	{
+        rgb:  '#696969',
+    },
+    slategray:	{
+        rgb:  '#708090',
+    },
+    gray:	{
+        rgb:  '#808080',
+    },
+    lightslategray:	{
+        rgb:  '#778899',
+    },
+    darkgray:	{
+        rgb:  '#a9a9a9',
+    },
+    silver:	{
+        rgb:  '#c0c0c0',
+    },
+    lightgray:	{
+        rgb:  '#d3d3d3',
+    },
+    gainsboro:	{
+        rgb:  '#dcdcdc',
+    },
+};
+
+function NamedColorToRGBstring(name)
+{
+    const lowerName = name.toLowerCase();
+    if (namedColors.hasOwnProperty(lowerName)) return namedColors[lowerName].rgb;
+    return '#0088FF';
+}
+
+function ParseColor(rgbstring)
+{
+    if (typeof(rgbstring) === 'string') {
+        const lowerName = rgbstring.toLowerCase();
+        if (namedColors.hasOwnProperty(lowerName))
+            rgbstring = namedColors[lowerName].rgb;
+        rgbstring = rgbstring.trim();
+        if (rgbstring.startsWith('#')) rgbstring = rgbstring.slice(1);
+        const val = parseInt('0x'+rgbstring);
+        const oneColor = {};
+        oneColor.r = Math.floor(val / (256*256));
+        oneColor.g = Math.floor(val % (256*256) / 256);
+        oneColor.b = val % 256;
+        return oneColor;
+    }
+    return {r:0,g:128,b:255};
+}
+
+function NamedColorToRGB(name)
+{
+    if (namedColors.hasOwnProperty(name)) return ParseColor(namedColors[name].rgb);
+    return {r:0,g:128,b:255};
+}
+
+exports.NamedColorToRGB = NamedColorToRGB;
+exports.NamedCOlorToRGBString = NamedColorToRGBstring;
+exports.ParseColor = ParseColor;

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -39,28 +39,28 @@ const comb = {
     },
     effectJson: (state, value, options, disableQueue) => {
         if (state.id === states.effect_json.id) {
-            let effectjson = {}
+            const effectjson = {};
             try {
-                if (options.hasOwnProperty("effect_speed"))
+                if (options.hasOwnProperty('effect_speed'))
                     effectjson.speed = options.effect_speed;
-                if (options.hasOwnProperty("effect_type"))
+                if (options.hasOwnProperty('effect_type'))
                     effectjson.effect = options.effect_type;
 
-                if (options.hasOwnProperty("effect_colors"))
+                if (options.hasOwnProperty('effect_colors'))
                     effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);
-//               effectjson = JSON.parse(value);
+                //               effectjson = JSON.parse(value);
             }
             catch {
-                let effectjson = {
+                const effectjson = {
                     colors:[{r: 255,g: 0,b: 0},{r: 0,g: 255,b: 0},{r: 0,g: 0,b: 255}],
                     speed:10,
-                    effect:"glow",
+                    effect:'glow',
                 };
-                if (options.hasOwnProperty("effect_speed"))
+                if (options.hasOwnProperty('effect_speed'))
                     effectjson.speed = options.effect_speed;
-                if (options.hasOwnProperty("effect_colors"))
+                if (options.hasOwnProperty('effect_colors'))
                     effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);
-                if (options.hasOwnProperty("effect_type"))
+                if (options.hasOwnProperty('effect_type'))
                     effectjson.effect = options.effect_type;
 
             }
@@ -502,7 +502,7 @@ const devices = [
             states.plug_temperature,
             states.plug_consumer_connected, states.plug_consumer_overloaded, states.plug_power_outage_memory,
             states.plug_auto_off, states.plug_led_disabled_night
-       ],
+        ],
     },
     {
         models: ['ZNCZ02LM'],
@@ -569,7 +569,7 @@ const devices = [
         models: ['LLKZMK11LM'],
         icon: 'img/lumi_relay.png',
         states: [states.channel1_state, states.channel2_state, states.load_power,
-                 states.temperature, states.interlock],
+            states.temperature, states.interlock],
     },
     {
         models: ['ZNCLDJ11LM'],
@@ -1574,12 +1574,12 @@ const devices = [
         states: [
             states.co2,
             states.temperature,
-			states.humidity,
-			states.pressure,
-			states.airsense_led_feedback,
-			states.airsense_enable_abc,
-			states.airsense_threshold1,
-			states.airsense_threshold2,
+            states.humidity,
+            states.pressure,
+            states.airsense_led_feedback,
+            states.airsense_enable_abc,
+            states.airsense_threshold1,
+            states.airsense_threshold2,
         ],
     },
     // ptvo
@@ -2033,7 +2033,7 @@ const devices = [
         models: ['ROB_200-010-0'],
         icon: 'img/sunricher_dimmer.png',
         states: [states.curtain_position, states.curtain_running, states.curtain_stop, states.invert_cover, // necessary
-                 states.channel1_state, states.channel2_state                                               // useful for testing with a bulb if no motor available yet
+            states.channel1_state, states.channel2_state                                               // useful for testing with a bulb if no motor available yet
         ],
     },
     {
@@ -2287,8 +2287,8 @@ const devices = [
             states.tuya_trv_boost_time,
             states.tuya_trv_comfort_temp,
             states.tuya_trv_eco_temp,
-            // states.climate_preset,
-//            states.climate_system_mode, removed: Tuya Thermostat does not recognize any mode aside "auto" (asgothian)
+            states.climate_preset,
+            //            states.climate_system_mode, removed: Tuya Thermostat does not recognize any mode aside "auto" (asgothian)
             states.tuya_trv_force_mode,
             states.tuya_trv_valve_position
         ],
@@ -2308,9 +2308,9 @@ const devices = [
             states.tuya_trv_target_temperature,
         ],
     },
-	// 3rd-party Tuya
+    // 3rd-party Tuya
 
-   {
+    {
         models: ['BHT-002-GCLZB'],
         icon: 'img/Moes_Wall_Thermostat.png',
         states: [
@@ -2340,7 +2340,7 @@ const devices = [
     },
     {
         models: ['TS0502A'],
-        icon: 'img/TS0502A.png', 
+        icon: 'img/TS0502A.png',
         states: lightStatesWithColortemp,
         syncStates: [sync.brightness],
     },
@@ -2755,12 +2755,12 @@ const devices = [
         states: [],
     },
 
-	// lidl kette
+    // lidl kette
     {
     	models: ['HG06467'],
     	icon: 'img/HG06467.png',
     	states: [states.brightness, states.color_hs, states.state, states.effect_json,
-        states.effect_speed, states.effect_type, states.effect_colors, states.transition_time],
+            states.effect_speed, states.effect_type, states.effect_colors, states.transition_time],
     	linkedStates: [comb.brightnessAndState, comb.effectJson],
     },
 

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -5,6 +5,7 @@ const statesDefs = require(__dirname + '/states.js').states;
 const safeJsonStringify = require('./json');
 const rgb = require(__dirname + '/rgb.js');
 const utils = require(__dirname + '/utils.js');
+const colors = require(__dirname + '/colors.js');
 
 function genState(expose, role, name, desc) {
     let state;
@@ -27,7 +28,7 @@ function genState(expose, role, name, desc) {
                 getter: payload => (payload[propName] === (expose.value_on || 'ON')),
                 setter: (value) => (value) ? (expose.value_on || 'ON') : (expose.value_off || 'OFF'),
                 setattr: expose.name,
-            }
+            };
             if (expose.endpoint) {
                 state.epname = expose.endpoint;
             }
@@ -46,7 +47,7 @@ function genState(expose, role, name, desc) {
                 min: expose.value_min || 0,
                 max: expose.value_max,
                 unit: expose.unit,
-            }
+            };
             if (expose.endpoint) {
                 state.epname = expose.endpoint;
             }
@@ -63,7 +64,7 @@ function genState(expose, role, name, desc) {
                 read: true,
                 type: 'string',
                 states: expose.values.map((item) => `${item}:${item}`).join(';'),
-            }
+            };
             if (expose.endpoint) {
                 state.epname = expose.endpoint;
             }
@@ -79,7 +80,7 @@ function genState(expose, role, name, desc) {
                 write: write,
                 read: true,
                 type: 'string',
-            }
+            };
             if (expose.endpoint) {
                 state.epname = expose.endpoint;
             }
@@ -94,360 +95,499 @@ function genState(expose, role, name, desc) {
 
 function createFromExposes(model, def) {
     const states = [];
-    let icon = `https://www.zigbee2mqtt.io/images/devices/${model}.jpg`;
+    const icon = `https://www.zigbee2mqtt.io/images/devices/${model}.jpg`;
     for (const expose of def.exposes) {
         let state;
 
         switch (expose.type) {
-        case 'light':
-            for (const prop of expose.features) {
-                switch (prop.name) {
-                    case 'state':
-                        const stateNameS = expose.endpoint ? `state_${expose.endpoint}` : 'state';
-                        states.push({
-                            id: stateNameS,
-                            name: `Switch state ${expose.endpoint ? expose.endpoint : ''}`.trim(),
-                            icon: undefined,
-                            role: 'switch',
-                            write: true,
-                            read: true,
-                            type: 'boolean',
-                            getter: (payload) => (payload[stateNameS] === (prop.value_on || 'ON')),
-                            setter: (value) => (value) ? prop.value_on || 'ON' : prop.value_off || 'OFF',
-                            epname: expose.endpoint,
-                            setattr: 'state',
-                        });
-                        break;
+            case 'light':
+                for (const prop of expose.features) {
+                    switch (prop.name) {
+                        case 'state':
+                            const stateNameS = expose.endpoint ? `state_${expose.endpoint}` : 'state';
+                            states.push({
+                                id: stateNameS,
+                                name: `Switch state ${expose.endpoint ? expose.endpoint : ''}`.trim(),
+                                icon: undefined,
+                                role: 'switch',
+                                write: true,
+                                read: true,
+                                type: 'boolean',
+                                getter: (payload) => (payload[stateNameS] === (prop.value_on || 'ON')),
+                                setter: (value) => (value) ? prop.value_on || 'ON' : prop.value_off || 'OFF',
+                                epname: expose.endpoint,
+                                setattr: 'state',
+                            });
+                            break;
 
-                    case 'brightness':
-                        const stateNameB = expose.endpoint ? `brightness_${expose.endpoint}` : 'brightness';
-                        states.push({
-                            id: stateNameB,
-                            name: `Brightness ${expose.endpoint ? expose.endpoint : ''}`.trim(),
-                            icon: undefined,
-                            role: 'level.dimmer',
-                            write: true,
-                            read: true,
-                            type: 'number',
-                            min: 0, // ignore expose.value_min
-                            max: 100, // ignore expose.value_max
-                            inOptions: true,
-                            getter: payload => {
-                                return utils.bulbLevelToAdapterLevel(payload[stateNameB]);
-                            },
-                            setter: (value) => {
-                                return utils.adapterLevelToBulbLevel(value);
-                            },
-                            setterOpt: (value, options) => {
-                                const hasTransitionTime = options && options.hasOwnProperty('transition_time');
-                                const transitionTime = hasTransitionTime ? options.transition_time : 0;
-                                const preparedOptions = {...options, transition: transitionTime};
-                                preparedOptions.brightness = utils.adapterLevelToBulbLevel(value);
-                                return preparedOptions;
-                            },
-                            readResponse: (resp) => {
-                                const respObj = resp[0];
-                                if (respObj.status === 0 && respObj.attrData != undefined) {
-                                    return utils.bulbLevelToAdapterLevel(respObj.attrData);
-                                }
-                            },
-                            epname: expose.endpoint,
-                            setattr: 'brightness',
-                        });
-                        break;
+                        case 'brightness':
+                            const stateNameB = expose.endpoint ? `brightness_${expose.endpoint}` : 'brightness';
+                            states.push({
+                                id: stateNameB,
+                                name: `Brightness ${expose.endpoint ? expose.endpoint : ''}`.trim(),
+                                icon: undefined,
+                                role: 'level.dimmer',
+                                write: true,
+                                read: true,
+                                type: 'number',
+                                min: 0, // ignore expose.value_min
+                                max: 100, // ignore expose.value_max
+                                inOptions: true,
+                                getter: payload => {
+                                    return utils.bulbLevelToAdapterLevel(payload[stateNameB]);
+                                },
+                                setter: (value) => {
+                                    return utils.adapterLevelToBulbLevel(value);
+                                },
+                                setterOpt: (value, options) => {
+                                    const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+                                    const transitionTime = hasTransitionTime ? options.transition_time : 0;
+                                    const preparedOptions = {...options, transition: transitionTime};
+                                    preparedOptions.brightness = utils.adapterLevelToBulbLevel(value);
+                                    return preparedOptions;
+                                },
+                                readResponse: (resp) => {
+                                    const respObj = resp[0];
+                                    if (respObj.status === 0 && respObj.attrData != undefined) {
+                                        return utils.bulbLevelToAdapterLevel(respObj.attrData);
+                                    }
+                                },
+                                epname: expose.endpoint,
+                                setattr: 'brightness',
+                            });
+                            break;
 
-                    case 'color_temp':
-                        const stateNameT = expose.endpoint ? `colortemp_${expose.endpoint}` : 'colortemp';
-                        states.push({
-                            id: stateNameT,
-                            prop: expose.endpoint ? `color_temp_${expose.endpoint}` : 'color_temp',
-                            name: `Color temperature ${expose.endpoint ? expose.endpoint : ''}`.trim(),
-                            icon: undefined,
-                            role: 'level.color.temperature',
-                            write: true,
-                            read: true,
-                            type: 'number',
-                            min: expose.value_min,
-                            max: expose.value_max,
-                            setter: (value) => { 
-                                return utils.toMired(value) 
-                            },
-                            setterOpt: (value, options) => {
-                                const hasTransitionTime = options && options.hasOwnProperty('transition_time');
-                                const transitionTime = hasTransitionTime ? options.transition_time : 0;
-                                return {...options, transition: transitionTime};
-                            },
-                            epname: expose.endpoint,
-                        });
-                        break;
+                        case 'color_temp':
+                            const stateNameT = expose.endpoint ? `colortemp_${expose.endpoint}` : 'colortemp';
+                            states.push({
+                                id: stateNameT,
+                                prop: expose.endpoint ? `color_temp_${expose.endpoint}` : 'color_temp',
+                                name: `Color temperature ${expose.endpoint ? expose.endpoint : ''}`.trim(),
+                                icon: undefined,
+                                role: 'level.color.temperature',
+                                write: true,
+                                read: true,
+                                type: 'number',
+                                min: expose.value_min,
+                                max: expose.value_max,
+                                setter: (value) => {
+                                    return utils.toMired(value);
+                                },
+                                setterOpt: (value, options) => {
+                                    const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+                                    const transitionTime = hasTransitionTime ? options.transition_time : 0;
+                                    return {...options, transition: transitionTime};
+                                },
+                                epname: expose.endpoint,
+                            });
+                            break;
 
-                    case 'color_xy':
-                        const stateNameC = expose.endpoint ? `color_${expose.endpoint}` : 'color';
-                        states.push({
-                            id: stateNameC,
-                            prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
-                            name: `Color ${expose.endpoint ? expose.endpoint : ''}`.trim(),
-                            icon: undefined,
-                            role: 'level.color.rgb',
-                            write: true,
-                            read: true,
-                            type: 'string',
-                            setter: (value) => {
+                        case 'color_xy':
+                            const stateNameC = expose.endpoint ? `color_${expose.endpoint}` : 'color';
+                            states.push({
+                                id: stateNameC,
+                                prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
+                                name: `Color ${expose.endpoint ? expose.endpoint : ''}`.trim(),
+                                icon: undefined,
+                                role: 'level.color.rgb',
+                                write: true,
+                                read: true,
+                                type: 'string',
+                                setter: (value) => {
                                 // convert RGB to XY for set
-                                const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
-                                let xy = [0, 0];
-                                if (result) {
-                                    const r = parseInt(result[1], 16),
-                                        g = parseInt(result[2], 16),
-                                        b = parseInt(result[3], 16);
-                                    xy = rgb.rgb_to_cie(r, g, b);
-                                }
-                                return {
-                                    x: xy[0],
-                                    y: xy[1]
-                                };
-                            },
-                            setterOpt: (value, options) => {
-                                const hasTransitionTime = options && options.hasOwnProperty('transition_time');
-                                const transitionTime = hasTransitionTime ? options.transition_time : 0;
-                                return {...options, transition: transitionTime};
-                            },
-                            getter: payload => {
-                                if (payload.color && payload.color.hasOwnProperty("x") && payload.color.hasOwnProperty("y")) {
-                                    const colorval = rgb.cie_to_rgb(payload.color.x, payload.color.y);
-                                    return '#' + utils.decimalToHex(colorval[0]) + utils.decimalToHex(colorval[1]) + utils.decimalToHex(colorval[2]);
-                                } else {
-                                    return undefined;
-                                }
-                            },
-                            epname: expose.endpoint,
-                            setattr: 'color',
-                        });
-                        break;
+                                    /*
+                                    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
+                                    let xy = [0, 0];
+                                    if (result) {
+                                        const r = parseInt(result[1], 16),
+                                            g = parseInt(result[2], 16),
+                                            b = parseInt(result[3], 16);
+                                        xy = rgb.rgb_to_cie(r, g, b);
+                                    }
+                                    return {
+                                        x: xy[0],
+                                        y: xy[1]
+                                    };
+*/
+                                    let xy = [0, 0];
+                                    const rgbcolor = colors.ParseColor(value);
 
-                    case 'color_hs':
-                        const stateNameH = expose.endpoint ? `color_${expose.endpoint}` : 'color';
-                        states.push({
-                            id: stateNameH,
-                            prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
-                            name: `Color ${expose.endpoint ? expose.endpoint : ''}`.trim(),
-                            icon: undefined,
-                            role: 'level.color.rgb',
-                            write: true,
-                            read: true,
-                            type: 'string',
-                            setter: (value) => {
+                                    xy = rgb.rgb_to_cie(rgbcolor.r, rgbcolor.g, rgbcolor.b);
+                                    return {
+                                        x: xy[0],
+                                        y: xy[1]
+                                    };
+
+                                },
+                                setterOpt: (value, options) => {
+                                    const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+                                    const transitionTime = hasTransitionTime ? options.transition_time : 0;
+                                    return {...options, transition: transitionTime};
+                                },
+                                getter: payload => {
+                                    if (payload.color && payload.color.hasOwnProperty('x') && payload.color.hasOwnProperty('y')) {
+                                        const colorval = rgb.cie_to_rgb(payload.color.x, payload.color.y);
+                                        return '#' + utils.decimalToHex(colorval[0]) + utils.decimalToHex(colorval[1]) + utils.decimalToHex(colorval[2]);
+                                    } else {
+                                        return undefined;
+                                    }
+                                },
+                                epname: expose.endpoint,
+                                setattr: 'color',
+                            });
+                            break;
+
+                        case 'color_hs':
+                            const stateNameH = expose.endpoint ? `color_${expose.endpoint}` : 'color';
+                            states.push({
+                                id: stateNameH,
+                                prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
+                                name: `Color ${expose.endpoint ? expose.endpoint : ''}`.trim(),
+                                icon: undefined,
+                                role: 'level.color.rgb',
+                                write: true,
+                                read: true,
+                                type: 'string',
+                                setter: (value) => {
                                 // convert RGB to HS for set
-                                const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
-                                let hsv = {h: 0, s: 0, v:0};
-                                if (result) {
-                                    const r = parseInt(result[1], 16),
-                                        g = parseInt(result[2], 16),
-                                        b = parseInt(result[3], 16);
-                                    hsv = rgb.rgbToHSV(r, g, b);
-                                }
-                                return {
-                                    hue: hsv.h,
-                                    saturation: hsv.s,
-                                };
-                            },
-                            setterOpt: (value, options) => {
-                                const hasTransitionTime = options && options.hasOwnProperty('transition_time');
-                                const transitionTime = hasTransitionTime ? options.transition_time : 0;
-                                return {...options, transition: transitionTime};
-                            },
-                            epname: expose.endpoint,
-                            setattr: 'color',
-                        });
-                        break;
+                                    /*
+                                    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
+                                    let hsv = {h: 0, s: 0, v:0};
+                                    if (result) {
+                                        const r = parseInt(result[1], 16),
+                                            g = parseInt(result[2], 16),
+                                            b = parseInt(result[3], 16);
+                                        hsv = rgb.rgbToHSV(r, g, b);
+                                    }
+                                    return {
+                                        hue: hsv.h,
+                                        saturation: hsv.s,
+                                    };
+*/
+                                    const _rgb = colors.ParseColor(value);
+                                    const hsv = rgb.rgbToHSV(_rgb.r, _rgb.g, _rgb.b, true);
+                                    return {
+                                        hue: Math.min(Math.max(hsv.h,1),359),
+                                        saturation: hsv.s,
+                                        //                                        brightness: Math.floor(hsv.v * 2.55),
 
-                    default:
-                        states.push(genState(prop));
-                        break;
-                }
-            }
-            states.push(statesDefs.transition_time);
-            break;
+                                    };
+                                },
+                                setterOpt: (value, options) => {
+                                    const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+                                    const transitionTime = hasTransitionTime ? options.transition_time : 0;
+                                    return {...options, transition: transitionTime};
+                                },
+                                epname: expose.endpoint,
+                                setattr: 'color',
+                            });
+                            states.push({
+                                id: expose.endpoint ? `hue_${expose.endpoint}` : 'hue',
+                                prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
+                                name: `Hue ${expose.endpoint ? expose.endpoint : ''}`.trim(),
+                                icon: undefined,
+                                role: 'level.color.hue',
+                                write: true,
+                                read: false,
+                                type: 'number',
+                                min: 0,
+                                max: 360,
+                                inOptions: true,
+                                setter: (value, options) => {
+                                    return {
+                                        hue: value,
+                                        saturation: options.saturation,
+                                    };
+                                },
+                                setterOpt: (value, options) => {
+                                    const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+                                    const transitionTime = hasTransitionTime ? options.transition_time : 0;
+                                    const hasHueCalibrationTable = options && options.hasOwnProperty('hue_calibration');
+                                    if (hasHueCalibrationTable)
+                                        try {
+                                            return {...options, transition: transitionTime, hue_correction: JSON.parse(options.hue_calibration)};
+                                        }
+                                        catch {
+                                            const hue_correction_table = [];
+                                            options.hue_calibration.split(',').forEach(element => {
+                                                const match = /([0-9]+):([0-9]+)/.exec(element);
+                                                if (match && match.length ==3)
+                                                    hue_correction_table.push({ in: Number(match[1]), out: Number(match[2])});
+                                            });
+                                            if (hue_correction_table.length > 0)
+                                                return {...options, transition: transitionTime, hue_correction: hue_correction_table};
+                                        }
+                                    return {...options, transition: transitionTime};
+                                },
 
-        case 'switch':
-            for (const prop of expose.features) {
-                switch (prop.name) {
-                    case 'state':
-                        states.push(genState(prop, 'switch'));
-                        break;
-                    default:
-                        states.push(genState(prop));
-                        break;
-                }
-            }
-            break;
+                            });
+                            states.push({
+                                id: expose.endpoint ? `saturation_${expose.endpoint}` : 'saturation',
+                                prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
+                                name: `Saturation ${expose.endpoint ? expose.endpoint : ''}`.trim(),
+                                icon: undefined,
+                                role: 'level.color.saturation',
+                                write: true,
+                                read: false,
+                                type: 'number',
+                                min: 0,
+                                max: 100,
+                                inOptions: true,
+                                setter: (value, options) => {
+                                    return {
+                                        hue: options.hue,
+                                        saturation: value,
+                                    };
+                                },
+                                setterOpt: (value, options) => {
+                                    const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+                                    const transitionTime = hasTransitionTime ? options.transition_time : 0;
+                                    const hasHueCalibrationTable = options && options.hasOwnProperty('hue_calibration');
+                                    if (hasHueCalibrationTable)
+                                        try {
+                                            return {...options, transition: transitionTime, hue_correction: JSON.parse(options.hue_calibration)};
+                                        }
+                                        catch {
+                                            const hue_correction_table = [];
+                                            options.hue_calibration.split(',').forEach(element => {
+                                                const match = /([0-9]+):([0-9]+)/.exec(element);
+                                                if (match && match.length ==3)
+                                                    hue_correction_table.push({ in: Number(match[1]), out: Number(match[2])});
+                                            });
+                                            if (hue_correction_table.length > 0)
+                                                return {...options, transition: transitionTime, hue_correction: hue_correction_table};
+                                        }
+                                    return {...options, transition: transitionTime};
+                                },
 
-        case 'numeric':
-            switch (expose.name) {
-            case 'linkquality':
-                state = undefined;
-                break;
+                            });
+                            states.push({
+                                id: 'hue_calibration',
+                                prop: 'color',
+                                name: 'Hue color calibration table',
+                                icon: undefined,
+                                role: 'table',
+                                write: true,
+                                read: false,
+                                type: 'string',
+                                inOptions: true,
+                                setter: (value, options) => {
+                                    return {
+                                        hue: options.hue,
+                                        saturation: options.saturation,
+                                    };
+                                },
+                                setterOpt: (value, options) => {
+                                    const hasTransitionTime = options && options.hasOwnProperty('transition_time');
+                                    const transitionTime = hasTransitionTime ? options.transition_time : 0;
+                                    const hasHueCalibrationTable = options && options.hasOwnProperty('hue_calibration');
+                                    if (hasHueCalibrationTable)
+                                        try {
+                                            return {...options, transition: transitionTime, hue_correction: JSON.parse(options.hue_calibration)};
+                                        }
+                                        catch {
+                                            const hue_correction_table = [];
+                                            options.hue_calibration.split(',').forEach(element => {
+                                                const match = /([0-9]+):([0-9]+)/.exec(element);
+                                                if (match && match.length ==3)
+                                                    hue_correction_table.push({ in: Number(match[1]), out: Number(match[2])});
+                                            });
+                                            if (hue_correction_table.length > 0)
+                                                return {...options, transition: transitionTime, hue_correction: hue_correction_table};
+                                        }
+                                    return {...options, transition: transitionTime};
+                                },
 
-            case 'battery':
-                state = statesDefs.battery;
-                break;
+                            });
+                            break;
 
-            case 'voltage':
-                state = statesDefs.voltage;
-                break;
-
-            case 'temperature':
-                state = statesDefs.temperature;
-                break;
-
-            case 'humidity':
-                state = statesDefs.humidity;
-                break;
-
-            case 'pressure':
-                state = statesDefs.pressure;
-                break;
-
-            case 'illuminance':
-                state = statesDefs.illuminance_raw;
-                break;
-
-            case 'illuminance_lux':
-                state = statesDefs.illuminance;
-                break;
-
-            case 'power':
-                state = statesDefs.load_power;
-                break;
-
-            default:
-                state = genState(expose);
-                break;
-            }
-            if (state) states.push(state);
-            break;
-
-        case 'enum':
-            switch (expose.name) {
-            case 'action':
-                if (!Array.isArray(expose.values)) break;
-                const hasHold = expose.values.find((actionName) => actionName.includes('hold'));
-                const hasRelease = expose.values.find((actionName) => actionName.includes('release'));
-                for (const actionName of expose.values) {
-                    // is release state ? - skip
-                    if (hasHold && hasRelease && actionName.includes('release')) continue;
-                    // is hold state ?
-                    if (hasHold && hasRelease && actionName.includes('hold')) {
-                        const releaseActionName = actionName.replace('hold', 'release');
-                        state = {
-                            id: actionName.replace(/\*/g, ''),
-                            prop: 'action',
-                            name: actionName,
-                            icon: undefined,
-                            role: 'button',
-                            write: false,
-                            read: true,
-                            type: 'boolean',
-                            getter: payload => (payload.action === actionName) ? true : (payload.action === releaseActionName) ? false : undefined,
-                        };
-                    } else {
-                        state = {
-                            id: actionName.replace(/\*/g, ''),
-                            prop: 'action',
-                            name: actionName,
-                            icon: undefined,
-                            role: 'button',
-                            write: false,
-                            read: true,
-                            type: 'boolean',
-                            getter: payload => (payload.action === actionName) ? true : undefined,
-                            isEvent: true,
-                        };
+                        default:
+                            states.push(genState(prop));
+                            break;
                     }
-                    states.push(state);
                 }
-                state = null;
+                states.push(statesDefs.transition_time);
                 break;
 
-            default:
-                state = genState(expose);
-                break;
-            }
-            if (state) states.push(state);
-            break;
-
-        case 'binary':
-            switch (expose.name) {
-            case 'contact':
-                state = statesDefs.contact;
-                states.push(statesDefs.opened);
-                break;
-
-            case 'battery_low':
-                state = statesDefs.heiman_batt_low;
+            case 'switch':
+                for (const prop of expose.features) {
+                    switch (prop.name) {
+                        case 'state':
+                            states.push(genState(prop, 'switch'));
+                            break;
+                        default:
+                            states.push(genState(prop));
+                            break;
+                    }
+                }
                 break;
 
-            case 'tamper':
-                state = statesDefs.tamper;
-                break;
-
-            case 'water_leak':
-                state = statesDefs.water_detected;
-                break;
-
-            case 'lock':
-                state = stateDefs.child_lock
-                break;
-
-            case 'occupancy':
-                state = statesDefs.occupancy;
-                break;
-
-            default:
-                state = genState(expose);
-                break;
-            }
-            if (state) states.push(state);
-            break;
-
-        case 'text':
-            state = genState(expose);
-            states.push(state);
-            break;
-
-        case 'cover':
-            for (const prop of expose.features) {
-                switch (prop.name) {
-                    case 'state':
-                        states.push(genState(prop, 'switch'));
+            case 'numeric':
+                switch (expose.name) {
+                    case 'linkquality':
+                        state = undefined;
                         break;
+
+                    case 'battery':
+                        state = statesDefs.battery;
+                        break;
+
+                    case 'voltage':
+                        state = statesDefs.voltage;
+                        break;
+
+                    case 'temperature':
+                        state = statesDefs.temperature;
+                        break;
+
+                    case 'humidity':
+                        state = statesDefs.humidity;
+                        break;
+
+                    case 'pressure':
+                        state = statesDefs.pressure;
+                        break;
+
+                    case 'illuminance':
+                        state = statesDefs.illuminance_raw;
+                        break;
+
+                    case 'illuminance_lux':
+                        state = statesDefs.illuminance;
+                        break;
+
+                    case 'power':
+                        state = statesDefs.load_power;
+                        break;
+
                     default:
-                        states.push(genState(prop));
+                        state = genState(expose);
                         break;
                 }
-            }
-            break;
+                if (state) states.push(state);
+                break;
 
-        case 'climate':
-            for (const prop of expose.features) {
-                switch (prop.name) {
-                    case 'away_mode':
-                        states.push(statesDefs.climate_away_mode);
+            case 'enum':
+                switch (expose.name) {
+                    case 'action':
+                        if (!Array.isArray(expose.values)) break;
+                        const hasHold = expose.values.find((actionName) => actionName.includes('hold'));
+                        const hasRelease = expose.values.find((actionName) => actionName.includes('release'));
+                        for (const actionName of expose.values) {
+                            // is release state ? - skip
+                            if (hasHold && hasRelease && actionName.includes('release')) continue;
+                            // is hold state ?
+                            if (hasHold && hasRelease && actionName.includes('hold')) {
+                                const releaseActionName = actionName.replace('hold', 'release');
+                                state = {
+                                    id: actionName.replace(/\*/g, ''),
+                                    prop: 'action',
+                                    name: actionName,
+                                    icon: undefined,
+                                    role: 'button',
+                                    write: false,
+                                    read: true,
+                                    type: 'boolean',
+                                    getter: payload => (payload.action === actionName) ? true : (payload.action === releaseActionName) ? false : undefined,
+                                };
+                            } else {
+                                state = {
+                                    id: actionName.replace(/\*/g, ''),
+                                    prop: 'action',
+                                    name: actionName,
+                                    icon: undefined,
+                                    role: 'button',
+                                    write: false,
+                                    read: true,
+                                    type: 'boolean',
+                                    getter: payload => (payload.action === actionName) ? true : undefined,
+                                    isEvent: true,
+                                };
+                            }
+                            states.push(state);
+                        }
+                        state = null;
                         break;
-                    case 'system_mode':
-                        states.push(statesDefs.climate_system_mode);
-                        break;
-                    case 'running_mode':
-                        states.push(statesDefs.climate_running_mode);
-                        break;
+
                     default:
-                        states.push(genState(prop));
+                        state = genState(expose);
                         break;
                 }
-            }
-            break;
-        default:
-            console.log(`Unhandled expose type ${expose.type} for device ${model}`);
+                if (state) states.push(state);
+                break;
+
+            case 'binary':
+                switch (expose.name) {
+                    case 'contact':
+                        state = statesDefs.contact;
+                        states.push(statesDefs.opened);
+                        break;
+
+                    case 'battery_low':
+                        state = statesDefs.heiman_batt_low;
+                        break;
+
+                    case 'tamper':
+                        state = statesDefs.tamper;
+                        break;
+
+                    case 'water_leak':
+                        state = statesDefs.water_detected;
+                        break;
+
+                    case 'lock':
+                        state = stateDefs.child_lock;
+                        break;
+
+                    case 'occupancy':
+                        state = statesDefs.occupancy;
+                        break;
+
+                    default:
+                        state = genState(expose);
+                        break;
+                }
+                if (state) states.push(state);
+                break;
+
+            case 'text':
+                state = genState(expose);
+                states.push(state);
+                break;
+
+            case 'cover':
+                for (const prop of expose.features) {
+                    switch (prop.name) {
+                        case 'state':
+                            states.push(genState(prop, 'switch'));
+                            break;
+                        default:
+                            states.push(genState(prop));
+                            break;
+                    }
+                }
+                break;
+
+            case 'climate':
+                for (const prop of expose.features) {
+                    switch (prop.name) {
+                        case 'away_mode':
+                            states.push(statesDefs.climate_away_mode);
+                            break;
+                        case 'system_mode':
+                            states.push(statesDefs.climate_system_mode);
+                            break;
+                        case 'running_mode':
+                            states.push(statesDefs.climate_running_mode);
+                            break;
+                        default:
+                            states.push(genState(prop));
+                            break;
+                    }
+                }
+                break;
+            default:
+                console.log(`Unhandled expose type ${expose.type} for device ${model}`);
         }
     }
     const newDev = {

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -249,21 +249,6 @@ function createFromExposes(model, def) {
                                 read: true,
                                 type: 'string',
                                 setter: (value) => {
-                                // convert RGB to HS for set
-                                    /*
-                                    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
-                                    let hsv = {h: 0, s: 0, v:0};
-                                    if (result) {
-                                        const r = parseInt(result[1], 16),
-                                            g = parseInt(result[2], 16),
-                                            b = parseInt(result[3], 16);
-                                        hsv = rgb.rgbToHSV(r, g, b);
-                                    }
-                                    return {
-                                        hue: hsv.h,
-                                        saturation: hsv.s,
-                                    };
-*/
                                     const _rgb = colors.ParseColor(value);
                                     const hsv = rgb.rgbToHSV(_rgb.r, _rgb.g, _rgb.b, true);
                                     return {

--- a/lib/ota.js
+++ b/lib/ota.js
@@ -50,7 +50,7 @@ class Ota {
             }
         }
     }
-    
+
     async checkOtaAvail(obj) {
         const device = await this.getDeviceForMessage(obj);
         if (!device) {
@@ -59,7 +59,7 @@ class Ota {
             return;
         }
         if (this.inProgress.has(device.device.ieeeAddr)) {
-            this.error(`Update or check already in progress for '${device.name}', skipping...`);
+            this.warn(`Update or check already in progress for '${device.name}', skipping...`);
             return;
         }
         this.inProgress.add(device.device.ieeeAddr);
@@ -79,7 +79,7 @@ class Ota {
             const message = `Failed to check if update available for '${device.name}' (${error.message})`;
             result.status = 'fail';
             result.msg = message;
-            this.error(message);
+            this.warn(message);
             this.adapter.sendTo(obj.from, obj.command, result, obj.callback);
         }
         this.inProgress.delete(device.device.ieeeAddr);

--- a/lib/rgb.js
+++ b/lib/rgb.js
@@ -39,7 +39,7 @@ THE SOFTWARE.
 */
 'use strict';
 
-
+const colors = require('./colors.js');
 
 /**
  * Converts CIE color space to RGB color space
@@ -160,12 +160,12 @@ function hsvToRGB(h, s, v) {
     const q = v * (1 - f * s);
     const t = v * (1 - (1 - f) * s);
     switch (i % 6) {
-    case 0: r = v, g = t, b = p; break;
-    case 1: r = q, g = v, b = p; break;
-    case 2: r = p, g = v, b = t; break;
-    case 3: r = p, g = q, b = v; break;
-    case 4: r = t, g = p, b = v; break;
-    case 5: r = v, g = p, b = q; break;
+        case 0: r = v, g = t, b = p; break;
+        case 1: r = q, g = v, b = p; break;
+        case 2: r = p, g = v, b = t; break;
+        case 3: r = p, g = q, b = v; break;
+        case 4: r = t, g = p, b = v; break;
+        case 5: r = v, g = p, b = q; break;
     }
     return {
         r: Math.round(r * 255),
@@ -185,10 +185,10 @@ function rgbToHSV(r, g, b, numeric) {
     const v = max / 255;
 
     switch (max) {
-    case min: h = 0; break;
-    case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
-    case g: h = (b - r) + d * 2; h /= 6 * d; break;
-    case b: h = (r - g) + d * 4; h /= 6 * d; break;
+        case min: h = 0; break;
+        case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
+        case g: h = (b - r) + d * 2; h /= 6 * d; break;
+        case b: h = (r - g) + d * 4; h /= 6 * d; break;
     }
     if (numeric) return {
         h: Math.round(h*360),
@@ -201,25 +201,25 @@ function rgbToHSV(r, g, b, numeric) {
         v: (v * 100).toFixed(3),
     };
 }
-function colorsArrayFromString(value) {
-    if (typeof(value) === "string") {
-        let rv = [];
-        value.split(",").forEach(element => {
-            let val = parseInt("0x"+element);
-            let oneColor = {};
-            oneColor.r = Math.floor(val / (256*256));
-            oneColor.g = Math.floor(val % (256*256) / 256);
-            oneColor.b = val % 256;
-            rv.push(oneColor);
+function colorArrayFromString(value) {
+    if (typeof(value) === 'string') {
+        const rv = [];
+        value.split(',').forEach(element => {
+            rv.push(colors.ParseColor(element));
         });
         return rv;
     }
     return [{r:0,g:128,b:255}];
 }
 
+function hsv_to_cie(h,s,v){
+    const rgb = hsvToRGB(h,s,v);
+    return rgb_to_cie(rgb.r, rgb.g, rgb.b);
+}
 
+exports.hsv_to_cie = hsv_to_cie;
 exports.rgb_to_cie = rgb_to_cie;
 exports.cie_to_rgb = cie_to_rgb;
 exports.hsvToRGB = hsvToRGB;
 exports.rgbToHSV = rgbToHSV;
-exports.colorsArrayFromString = colorsArrayFromString;
+exports.colorArrayFromString = colorArrayFromString;

--- a/lib/states.js
+++ b/lib/states.js
@@ -4,6 +4,7 @@
 
 const rgb = require(__dirname + '/rgb.js');
 const utils = require(__dirname + '/utils.js');
+const colors = require(__dirname + '/colors.js');
 
 /* states for device:
    id - sysname of state, id
@@ -1132,8 +1133,8 @@ const states = {
         write: true,
         read: true,
         type: 'number',
-        setter: (value) => { 
-            return utils.toMired(value) 
+        setter: (value) => {
+            return utils.toMired(value);
         },
         setterOpt: (value, options) => {
             const hasTransitionTime = options && options.hasOwnProperty('transition_time');
@@ -1141,7 +1142,7 @@ const states = {
             return {...options, transition: transitionTime};
         },
     },
-    
+
     color: {
         id: 'color',
         prop: 'color',
@@ -1152,15 +1153,21 @@ const states = {
         read: true,
         type: 'string',
         setter: (value) => {
+
             // convert RGB to XY for set
-            const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
-            let xy = [0, 0];
+            //            const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
+            /*
             if (result) {
                 const r = parseInt(result[1], 16),
                     g = parseInt(result[2], 16),
                     b = parseInt(result[3], 16);
                 xy = rgb.rgb_to_cie(r, g, b);
             }
+*/
+            let xy = [0, 0];
+            const rgbcolor = colors.ParseColor(value);
+
+            xy = rgb.rgb_to_cie(rgbcolor.r, rgbcolor.g, rgbcolor.g);
             return {
                 x: xy[0],
                 y: xy[1]
@@ -1172,7 +1179,7 @@ const states = {
             return {...options, transition: transitionTime};
         },
         getter: payload => {
-            if (payload.color && payload.color.hasOwnProperty("x") && payload.color.hasOwnProperty("y")) {
+            if (payload.color && payload.color.hasOwnProperty('x') && payload.color.hasOwnProperty('y')) {
                 const colorval = rgb.cie_to_rgb(payload.color.x, payload.color.y);
                 return '#' + utils.decimalToHex(colorval[0]) + utils.decimalToHex(colorval[1]) + utils.decimalToHex(colorval[2]);
             } else {
@@ -3854,6 +3861,7 @@ const states = {
         read: true,
         type: 'string',
         setter: (value) => {
+            /*
             // convert RGB to XY for set
             const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
             let xy = [0, 0];
@@ -3863,6 +3871,14 @@ const states = {
                     b = parseInt(result[3], 16);
                 xy = rgb.rgb_to_cie(r, g, b);
             }
+            return {
+                x: xy[0],
+                y: xy[1]
+            };
+            */
+            let xy = [0, 0];
+            const rgbcolor = colors.ParseColor(value);
+            xy = rgb.rgb_to_cie(rgbcolor.r, rgbcolor.g, rgbcolor.g);
             return {
                 x: xy[0],
                 y: xy[1]
@@ -5519,7 +5535,7 @@ const states = {
         type: 'boolean',
     },
     co2: {
-	    id: 'co2',
+        id: 'co2',
         prop: 'co2',
         name: 'co2',
         icon: undefined,
@@ -5527,9 +5543,9 @@ const states = {
         write: false,
         read: true,
         type: 'number',
-		unit: 'ppm',
-	},
-	    airsense_led_feedback: {
+        unit: 'ppm',
+    },
+    airsense_led_feedback: {
         id: 'led_feedback',
         name: 'Led feedback',
         icon: undefined,
@@ -5558,7 +5574,7 @@ const states = {
         read: true,
         type: 'number',
         unit: ''
-	},
+    },
     airsense_threshold2: {
         id: 'threshold2',
         name: 'Threshold2',
@@ -5568,7 +5584,7 @@ const states = {
         read: true,
         type: 'number',
         unit: ''
-	},
+    },
 
     effect_type: {
         id: 'effect_type',
@@ -5582,19 +5598,19 @@ const states = {
         type: 'string',
         states: 'steady:steady;snow:snow;rainbow:rainbow;snake:snake;twinkle:twinkle;firework:firework;horizontal_flag:horizontal_flag;waves:waves;updown:updown;vintage:vintage;fading:fading;collide:collide;strobe:strobe;sparkles:sparkles;carnaval:carnaval;glow:glow',
         setter: (value, options) => {
-            let effectjson = {
+            const effectjson = {
                 colors:[{r: 255,g: 0,b: 0},{r: 0,g: 255,b: 0},{r: 0,g: 0,b: 255}],
                 speed:10,
-                effect:"glow",
+                effect:'glow',
             };
-            if (options.hasOwnProperty("effect_speed"))
-              effectjson.speed = options.effect_speed;
-            if (options.hasOwnProperty("effect_colors"))
+            if (options.hasOwnProperty('effect_speed'))
+                effectjson.speed = options.effect_speed;
+            if (options.hasOwnProperty('effect_colors'))
             {
-                effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);
+                effectjson.colors = rgb.colorArrayFromString(options.effect_colors);
             }
             effectjson.effect = value;
-            return effectjson
+            return effectjson;
         }
     },
     effect_json: {
@@ -5611,19 +5627,19 @@ const states = {
                 return JSON.parse(value);
             }
             catch {
-                let effectjson = {
+                const effectjson = {
                     colors:[{r: 255,g: 0,b: 0},{r: 0,g: 255,b: 0},{r: 0,g: 0,b: 255}],
                     speed:10,
-                    effect:"glow",
+                    effect:'glow',
                 };
-                if (options.hasOwnProperty("effect_speed"))
-                  effectjson.speed = options.effect_speed;
-                if (options.hasOwnProperty("effect_colors"))
-                    effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);
-                if (options.hasOwnProperty("effect_type"))
+                if (options.hasOwnProperty('effect_speed'))
+                    effectjson.speed = options.effect_speed;
+                if (options.hasOwnProperty('effect_colors'))
+                    effectjson.colors = rgb.colorArrayFromString(options.effect_colors);
+                if (options.hasOwnProperty('effect_type'))
                     effectjson.effect = options.effect_type;
                 value = JSON.stringify(effectjson);
-                return effectjson
+                return effectjson;
             }
         },
     },
@@ -5641,17 +5657,17 @@ const states = {
         max: 64,
         unit: '',
         setter: (value, options) => {
-            let effectjson = {
+            const effectjson = {
                 colors:[{r: 255,g: 0,b: 0},{r: 0,g: 255,b: 0},{r: 0,g: 0,b: 255}],
                 speed:10,
-                effect:"snake",
+                effect:'snake',
             };
-            if (options.hasOwnProperty("effect_type"))
-              effectjson.effect = options.effect_type;
-            if (options.hasOwnProperty("effect_colors"))
-                effectjson.colors = rgb.colorsArrayFromString(options.effect_colors);
+            if (options.hasOwnProperty('effect_type'))
+                effectjson.effect = options.effect_type;
+            if (options.hasOwnProperty('effect_colors'))
+                effectjson.colors = rgb.colorArrayFromString(options.effect_colors);
             effectjson.speed = value;
-            return effectjson
+            return effectjson;
         }
     },
     effect_colors: {
@@ -5665,18 +5681,18 @@ const states = {
         read: true,
         type: 'string',
         setter: (value, options) => {
-            let effectjson = {
+            const effectjson = {
                 colors:[{r: 255,g: 0,b: 0},{r: 0,g: 255,b: 0},{r: 0,g: 0,b: 255}],
                 speed:10,
-                effect:"sparkle",
+                effect:'sparkle',
             };
 
-            if (options.hasOwnProperty("effect_speed"))
-              effectjson.speed = options.effect_speed;
-            if (options.hasOwnProperty("effect_type"))
+            if (options.hasOwnProperty('effect_speed'))
+                effectjson.speed = options.effect_speed;
+            if (options.hasOwnProperty('effect_type'))
                 effectjson.effect = options.effect_type;
-            effectjson.colors = rgb.colorsArrayFromString(value);
-            return effectjson
+            effectjson.colors = rgb.colorArrayFromString(value);
+            return effectjson;
         }
     },
 
@@ -5691,15 +5707,19 @@ const states = {
         type: 'string',
         setter: (value, options) => {
             // convert RGB to XY for set
+            /*
             const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
             let hsv = {h: 0, s: 0, v:0};
-            let _rgb = {r: 128, b:128, g: 128}
+            const _rgb = {r: 128, b:128, g: 128};
             if (result) {
                 const r = Math.min(parseInt(result[1], 16), 255),
                     g = Math.min(parseInt(result[2], 16),255),
                     b = Math.min(parseInt(result[3], 16), 255);
                 hsv = rgb.rgbToHSV(r, g, b, true);
             }
+*/
+            const _rgb = colors.ParseColor(value);
+            const hsv = rgb.rgbToHSV(_rgb.r, _rgb.g, _rgb.b, true);
             return {
                 hue: Math.min(Math.max(hsv.h,1),359),
                 saturation: hsv.s,

--- a/lib/states.js
+++ b/lib/states.js
@@ -3861,21 +3861,6 @@ const states = {
         read: true,
         type: 'string',
         setter: (value) => {
-            /*
-            // convert RGB to XY for set
-            const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(value);
-            let xy = [0, 0];
-            if (result) {
-                const r = parseInt(result[1], 16),
-                    g = parseInt(result[2], 16),
-                    b = parseInt(result[3], 16);
-                xy = rgb.rgb_to_cie(r, g, b);
-            }
-            return {
-                x: xy[0],
-                y: xy[1]
-            };
-            */
             let xy = [0, 0];
             const rgbcolor = colors.ParseColor(value);
             xy = rgb.rgb_to_cie(rgbcolor.r, rgbcolor.g, rgbcolor.g);

--- a/lib/states.js
+++ b/lib/states.js
@@ -4057,6 +4057,16 @@ const states = {
         type: 'string', // valid: low, medium, high
         states: 'off:off;auto:auto;manual:manual;comfort:comfort;eco:eco;boost:boost;complex:complex',
     },
+    climate_preset: {
+        id: 'preset',
+        name: 'Preset',
+        role: 'state',
+        icon: undefined,
+        write: true,
+        read: true,
+        type: 'string',
+        states: 'schedule:schedule;manual:manual;boost:boost;complex:complex;comfort:comfort;eco:eco',
+    },
     climate_away_mode: {
         id: 'away_mode',
         prop: 'away_mode',

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -171,6 +171,10 @@ class DeviceAvailability extends BaseExtension {
                 this.debug(`Publish available for ${ieeeAddr} = ${available}`);
                 this.zigbee.emit('publish', ieeeAddr.substr(2), entity.mapped.model, payload);
             }
+            if (!available) {
+                this.debug(`Publish LQ for ${ieeeAddr} = 0`);
+                this.zigbee.emit('publish', ieeeAddr.substr(2), entity.mapped.model, { linkquality: 0 });
+            }
         }
     }
 

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -67,22 +67,39 @@ class DeviceAvailability extends BaseExtension {
         }
     }
 
-    async handleIntervalPingable(device) {
+    async handleIntervalPingable(device, entity) {
         const ieeeAddr = device.ieeeAddr;
-        const resolvedEntity = await this.zigbee.resolveEntity(ieeeAddr);
+        const resolvedEntity = (entity ? entity: await this.zigbee.resolveEntity(ieeeAddr));
         if (!resolvedEntity) {
             this.debug(`Stop pinging '${ieeeAddr}' ${device.modelID}, device is not known anymore`);
             return;
         }
 
         if (this.isPingable(device)) {
+            // first see if we can "ping" the device by reading a Status
+            try {
+                for (const key of toZigbeeCandidates) {
+                    //                    this.warn(`searching if state  '${key}' of '${entity.device.ieeeAddr}' is readable after reconnect`);
+                    const converter = entity.mapped.toZigbee.find((tz) => tz.key.includes(key));
+                    if (converter) {
+                        await converter.convertGet(device.endpoints[0], key, {});
+                        this.debug(`Successful read state '${key}' of '${device.ieeeAddr}' in stead of pinging`);
+                        this.setTimerPingable(device);
+                        return;
+                    }
+                }
+            }
+            catch (error) {
+                this.warn(`Failed to read state of '${device.ieeeAddr}' when pinging`);
+            }
+
             try {
                 await device.ping();
                 this.publishAvailability(device, true);
                 this.debug(`Successfully pinged ${ieeeAddr} ${device.modelID}`);
             } catch (error) {
                 this.publishAvailability(device, false);
-                this.debug(`Failed to ping ${ieeeAddr} ${device.modelID}`);
+                this.warn(`Failed to ping ${ieeeAddr} ${device.modelID}`);
             } finally {
                 this.setTimerPingable(device);
             }
@@ -128,10 +145,8 @@ class DeviceAvailability extends BaseExtension {
             const used = [];
             try {
                 for (const key of toZigbeeCandidates) {
-                    //                    this.warn(`searching if state  '${key}' of '${entity.device.ieeeAddr}' is readable after reconnect`);
                     const converter = entity.mapped.toZigbee.find((tz) => tz.key.includes(key));
                     if (converter && !used.includes(converter)) {
-                        //                        this.warn(`Attempting to read state  '${key}' of '${entity.device.ieeeAddr}' after reconnect`);
                         await converter.convertGet(device.endpoints[0], key, {});
                         used.push(converter);
                     }

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -128,8 +128,10 @@ class DeviceAvailability extends BaseExtension {
             const used = [];
             try {
                 for (const key of toZigbeeCandidates) {
+                    //                    this.warn(`searching if state  '${key}' of '${entity.device.ieeeAddr}' is readable after reconnect`);
                     const converter = entity.mapped.toZigbee.find((tz) => tz.key.includes(key));
                     if (converter && !used.includes(converter)) {
+                        //                        this.warn(`Attempting to read state  '${key}' of '${entity.device.ieeeAddr}' after reconnect`);
                         await converter.convertGet(device.endpoints[0], key, {});
                         used.push(converter);
                     }

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -14,7 +14,13 @@ const forcedPingable = [
     zigbeeHerdsmanConverters.devices.find((d) => d.model === '014G2461')
 ];
 
-const toZigbeeCandidates = ['state', 'brightness', 'color', 'color_temp'];
+// asgothian: 29.12.2020: Removed color and color_temp from readable
+// state candidates as most states do not provide a getter to ikea_transform
+// the data from the herdsman back to the value needed, which
+// will result in warnings "illegal state x,y" or "illegal state h,s" for color
+// and possibly sudden changes in value due to the support for color_temp
+// in mired and Kelvin.
+const toZigbeeCandidates = ['state', 'brightness']; //, 'color', 'color_temp'];
 const Hours25 = 1000 * 60 * 60 * 25;
 
 /**
@@ -33,6 +39,9 @@ class DeviceAvailability extends BaseExtension {
                 this.publishAvailability(entity.device, true, true);
             }, 1000);
         });
+        this.startDevicePingQueue = []; // simple fifo array for starting device pings
+        this.startDevicePingTimeout = null; // handle for the timeout which empties the queue
+        this.startDevicePingDelay = 200; // 200 ms delay between starting the ping timeout
     }
 
     isPingable(device) {
@@ -49,17 +58,48 @@ class DeviceAvailability extends BaseExtension {
         return clients.filter((d) => this.isPingable(d));
     }
 
+    async registerDevicePing(device, entity) {
+        //        this.warn(`Called registerDevicePing for '${device}' of '${entity}'`);
+        if (!this.isPingable(device)) return;
+        // ensure we do not already have this device in the queue
+        this.startDevicePingQueue.forEach(item => {
+            if (item && item.device == device)
+                return;
+        });
+        this.startDevicePingQueue.push({device:device, entity:entity});
+        if (this.startDevicePingTimeout == null)
+            this.startDevicePingTimeout = setTimeout(async() => {
+                await this.startDevicePing();
+            }, this.startDevicePingDelay);
+    }
+
+    async startDevicePing() {
+        //        this.warn(JSON.stringify(this));
+        this.startDevicePingTimeout = null;
+        const item = this.startDevicePingQueue.shift();
+        if (this.startDevicePingQueue.length >0) {
+            this.startDevicePingTimeout = setTimeout(async() => {
+                await this.startDevicePing();
+            }, this.startDevicePingDelay);
+        }
+        if (item && item.hasOwnProperty('device')) {
+            this.handleIntervalPingable(item.device, item.entity);
+        }
+    }
     async onZigbeeStarted() {
         // As some devices are not checked for availability (e.g. battery powered devices)
-        // we mark all device as online by default.
+        // we mark these device as online by default.
+        // NOTE: The start of active pings for pingable devices is done separately,
+        // triggered by the 'new device' event to ensure that they are handled
+        // identically on reconnect, disconnect and new pair (as)
         const clients = await this.zigbee.getClients();
 
         for (const device of clients) {
-            this.publishAvailability(device, true);
 
             if (this.isPingable(device)) {
-                this.setTimerPingable(device);
+                //                this.setTimerPingable(device);
             } else {
+                this.publishAvailability(device, true);
                 this.timers[device.ieeeAddr] = setInterval(() => {
                     this.handleIntervalNotPingable(device);
                 },utils.secondsToMilliseconds(this.availability_timeout));
@@ -90,7 +130,8 @@ class DeviceAvailability extends BaseExtension {
                 }
             }
             catch (error) {
-                this.warn(`Failed to read state of '${device.ieeeAddr}' when pinging`);
+                // intentionally empty: Just present to ensure we cause no harm
+                // when reading the state fails. => fall back on standard Ping function
             }
 
             try {

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -93,12 +93,13 @@ class DeviceAvailability extends BaseExtension {
         // triggered by the 'new device' event to ensure that they are handled
         // identically on reconnect, disconnect and new pair (as)
         const clients = await this.zigbee.getClients();
-
+        //        this.warn('onZigbeeStarted called');
         for (const device of clients) {
 
             if (this.isPingable(device)) {
                 //                this.setTimerPingable(device);
             } else {
+                //                this.warn(`Setting '${device.ieeeAddr}'  as available - battery driven`);
                 this.publishAvailability(device, true);
                 this.timers[device.ieeeAddr] = setInterval(() => {
                     this.handleIntervalNotPingable(device);
@@ -211,11 +212,13 @@ class DeviceAvailability extends BaseExtension {
                 const payload = {available: available};
                 this.debug(`Publish available for ${ieeeAddr} = ${available}`);
                 this.zigbee.emit('publish', ieeeAddr.substr(2), entity.mapped.model, payload);
+                this.debug(`Publish LQ for ${ieeeAddr} = ${(available ? 10: 0)}`);
+                this.zigbee.emit('publish', ieeeAddr.substr(2), entity.mapped.model, { linkquality: (available ? 10: 0) });
             }
-            if (!available) {
-                this.debug(`Publish LQ for ${ieeeAddr} = 0`);
-                this.zigbee.emit('publish', ieeeAddr.substr(2), entity.mapped.model, { linkquality: 0 });
-            }
+        //    if (!available) {
+        //        this.debug(`Publish LQ for ${ieeeAddr} = 0`);
+        //        this.zigbee.emit('publish', ieeeAddr.substr(2), entity.mapped.model, { linkquality: 0 });
+        //    }
         }
     }
 

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -34,7 +34,7 @@ class ZigbeeController extends EventEmitter {
       ready - connection successfull ()
     */
     constructor() {
-        super();        
+        super();
         this._permitJoinTime = 0;
         this.extensions = [
             new DeviceAvailabilityExt(this, {}),
@@ -133,7 +133,7 @@ class ZigbeeController extends EventEmitter {
 
 
         // Call extensions
-        this.callExtensionMethod('onZigbeeStarted', []);
+        //        this.callExtensionMethod('onZigbeeStarted', []);
 
         // Log zigbee clients on startup
         const devices = await this.getClients();
@@ -145,6 +145,8 @@ class ZigbeeController extends EventEmitter {
         for (const device of devices) {
             const entity = await this.resolveEntity(device);
             // ensure that objects for all found clients are present
+            this.callExtensionMethod('handleIntervalPingable', [device, entity]);
+
             if (entity.mapped) this.emit('new', entity);
             this.info(
                 (entity.device.ieeeAddr) +
@@ -408,8 +410,9 @@ class ZigbeeController extends EventEmitter {
         this.debug('handleDeviceAnnounce', message);
         const entity = await this.resolveEntity(message.device || message.ieeeAddr);
         const friendlyName = entity.name;
-        this.debug(`Device '${friendlyName}' announced itself`);
+        this.warn(`Device '${friendlyName}' announced itself`);
         this.emit('pairing', `Device '${friendlyName}' announced itself`);
+        this.callExtensionMethod('handleIntervalPingable', [message.device, entity]);
         // if has modelID so can create device
         if (entity.device && entity.device._modelID) {
             entity.device.modelID = entity.device._modelID;
@@ -829,7 +832,7 @@ class ZigbeeController extends EventEmitter {
 
     async getChannelsEnergy() {
         const payload = {
-            dstaddr: 0x0, 
+            dstaddr: 0x0,
             dstaddrmode: 0x02,
             channelmask: 0x07FFF800,
             scanduration: 0x5,
@@ -837,8 +840,8 @@ class ZigbeeController extends EventEmitter {
             nwkmanageraddr: 0x0000
         };
         const energyScan = this.herdsman.adapter.znp.waitFor(
-            2, //unpi_1.Constants.Type.AREQ, 
-            5, //Subsystem.ZDO, 
+            2, //unpi_1.Constants.Type.AREQ,
+            5, //Subsystem.ZDO,
             'mgmtNwkUpdateNotify'
         );
         await this.herdsman.adapter.znp.request(

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -133,7 +133,7 @@ class ZigbeeController extends EventEmitter {
 
 
         // Call extensions
-        //        this.callExtensionMethod('onZigbeeStarted', []);
+        this.callExtensionMethod('onZigbeeStarted', []);
 
         // Log zigbee clients on startup
         const devices = await this.getClients();
@@ -145,7 +145,7 @@ class ZigbeeController extends EventEmitter {
         for (const device of devices) {
             const entity = await this.resolveEntity(device);
             // ensure that objects for all found clients are present
-            this.callExtensionMethod('handleIntervalPingable', [device, entity]);
+            this.callExtensionMethod('registerDevicePing', [device, entity]);
 
             if (entity.mapped) this.emit('new', entity);
             this.info(
@@ -412,7 +412,7 @@ class ZigbeeController extends EventEmitter {
         const friendlyName = entity.name;
         this.warn(`Device '${friendlyName}' announced itself`);
         this.emit('pairing', `Device '${friendlyName}' announced itself`);
-        this.callExtensionMethod('handleIntervalPingable', [message.device, entity]);
+        this.callExtensionMethod('registerDevicePing', [message.device, entity]);
         // if has modelID so can create device
         if (entity.device && entity.device._modelID) {
             entity.device.modelID = entity.device._modelID;
@@ -428,6 +428,10 @@ class ZigbeeController extends EventEmitter {
 
     async handleDeviceInterview(message) {
         this.debug('handleDeviceInterview', message);
+        // safeguard: We do not allow to start an interview if the network is not opened
+        if (message.status === 'started' && !this.herdsman.getPermitJoin()) {
+            this.warn(`Blocked interview for '${message.ieeeAddr}' because the network is closed`);
+        }
         const entity = await this.resolveEntity(message.device || message.ieeeAddr);
         const friendlyName = entity.name;
         if (message.status === 'successful') {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -412,7 +412,7 @@ class ZigbeeController extends EventEmitter {
         const friendlyName = entity.name;
         this.warn(`Device '${friendlyName}' announced itself`);
         this.emit('pairing', `Device '${friendlyName}' announced itself`);
-        this.callExtensionMethod('registerDevicePing', [message.device, entity]);
+        if (!this.herdsman.getPermitJoin()) this.callExtensionMethod('registerDevicePing', [message.device, entity]);
         // if has modelID so can create device
         if (entity.device && entity.device._modelID) {
             entity.device.modelID = entity.device._modelID;
@@ -431,6 +431,7 @@ class ZigbeeController extends EventEmitter {
         // safeguard: We do not allow to start an interview if the network is not opened
         if (message.status === 'started' && !this.herdsman.getPermitJoin()) {
             this.warn(`Blocked interview for '${message.ieeeAddr}' because the network is closed`);
+            return;
         }
         const entity = await this.resolveEntity(message.device || message.ieeeAddr);
         const friendlyName = entity.name;

--- a/main.js
+++ b/main.js
@@ -104,15 +104,15 @@ class Zigbee extends utils.Adapter {
         catch {
             debugversion = ' npm ...';
         }
- 
-        // installed version         
+
+        // installed version
         let gitVers = '';
         try {
             this.log.info('Starting Zigbee ' + debugversion);
 
-            await this.getForeignObject("system.adapter." + this.namespace, (err, obj) => {
+            await this.getForeignObject('system.adapter.' + this.namespace, (err, obj) => {
                 if (!err && obj && obj.common.installedFrom && obj.common.installedFrom.includes('://')) {
-                    let instFrom = obj.common.installedFrom;
+                    const instFrom = obj.common.installedFrom;
                     gitVers = gitVers + instFrom.replace('tarball','commit');
                 } else {
                     gitVers = obj.common.installedFrom;
@@ -417,6 +417,7 @@ class Zigbee extends utils.Adapter {
                         this.stController.syncDevStates(dev, model);
                     });
                 }
+                //                else this.log.warn(`Device ${safeJsonStringify(entity)} rejoined, no new device`);
             });
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.zigbee",
-  "version": "1.4.1",
+  "version": "1.4.1as",
   "author": {
     "name": "Kirov Ilya",
     "email": "kirovilya@gmail.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.zigbee",
-  "version": "1.4.1as",
+  "version": "1.4.1",
   "author": {
     "name": "Kirov Ilya",
     "email": "kirovilya@gmail.com"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "zigbee-herdsman": "0.13.41",
-    "zigbee-herdsman-converters": "13.0.29",
+    "zigbee-herdsman-converters": "13.0.35",
     "@iobroker/adapter-core": "^2.4.0",
     "tar": "^6.0.5",
     "typescript": "^4.0.5"


### PR DESCRIPTION
- Hue_calibration for exposed devices (Use requires PR on zigbee-herdsman-converters, PR is being worked on)
- fix Tuya Thermostat: restore lost property "preset"
- Change for Device Availability: Stagger initial ping by 200 ms to prevent network congestion due to a large number of ping requests
- Change for Device Availability: Ping request triggered on reconnect. Before the herdsman Ping function is used, the adapter attempts to read the "state" dp. If this is successful, no ping is sent and the state is set
- Change for Device Availability: Set link Quality to 0 when a device is not connected, 10 when it is reconnecting.
- fix for message "illegal properties x,y" - remove color and color_temp from readable states on device available again (Issue #607)
- RGB Color can now be entered as "named" color. Implemented names are taken from the list of extended web colors on wikipedia (https://en.wikipedia.org/wiki/Web_colors)
- change in how RGB color is parsed. Incomplete colors will now be parsed successfully. #FFF will result in R 0, G 15, B 255
- change in OTA: Message that a device does not respond for OTA query downgraded to "info" from "error"
