### PR TITLE
Device Query / Orphaned States

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -17,7 +17,7 @@ let devices = [],
     groups = {},
     devGroups = {},
     binding = [],
-    excludes = [],    
+    excludes = [],
     coordinatorinfo = {
         type: 'd2',
         version: 'd2',
@@ -262,6 +262,20 @@ function deleteConfirmation(id, name) {
     Materialize.updateTextFields();
 }
 
+function cleanConfirmation() {
+    const text = translateWord('Do you really want to clean the states?');
+    $('#modalclean').find('p').text(text);
+    $('#cforce').prop('checked', false);
+    $('#cforcediv').removeClass('hide');
+    $("#modalclean a.btn[name='yes']").unbind('click');
+    $("#modalclean a.btn[name='yes']").click(() => {
+        const force = $('#cforce').prop('checked');
+        cleanDeviceStates(force);
+    });
+    $('#modalclean').modal('open');
+    Materialize.updateTextFields();
+}
+
 function editName(id, name) {
     const dev = devices.find((d) => d._id == id);
     $('#modaledit').find("input[id='d_name']").val(name);
@@ -295,6 +309,20 @@ function deleteDevice(id, force) {
     showWaitingDialog('Device is being removed', 10);
 }
 
+
+function cleanDeviceStates(force) {
+    sendTo(namespace, 'cleanDeviceStates', {force: force}, function (msg) {
+        closeWaitingDialog();
+        if (msg) {
+            if (msg.error) {
+                showMessage(msg.error, _('Error'));
+            } else {
+                getDevices();
+            }
+        }
+    });
+    showWaitingDialog('Device is being removed', 10);
+}
 function renameDevice(id, name) {
     sendTo(namespace, 'renameDevice', {id: id, name: name}, function (msg) {
         if (msg) {
@@ -574,6 +602,9 @@ function load(settings, onChange) {
     // Signal to admin, that no changes yet
     onChange(false);
 
+    $('#state_cleanup_btn').click(function() {
+        cleanConfirmation();
+    });
     $('#fw_check_btn').click(function() {
         checkFwUpdate();
     });
@@ -639,7 +670,7 @@ function load(settings, onChange) {
             loadDeveloperTab(onChange);
         }
     });
-    
+
     $('#add_exclude').click(function() {
         addExcludeDialog();
     });
@@ -2211,7 +2242,7 @@ function addExcludeDialog() {
 }
 
 function addExclude(exclude_model) {
-      sendTo(namespace, 'addExclude', {       
+      sendTo(namespace, 'addExclude', {
          exclude_model: exclude_model
     }, function (msg) {
         closeWaitingDialog();
@@ -2263,7 +2294,7 @@ function showExclude() {
                                         <ul>
                                             <li><span class="label">model:</span><span>${modelUrl}</span></li>
                                         </ul>
-                                    </div>                                
+                                    </div>
                             </div>
                             <div class="card-action">
                                 <div class="card-reveal-buttons zcard">

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -263,7 +263,7 @@ function deleteConfirmation(id, name) {
 }
 
 function cleanConfirmation() {
-    const text = translateWord('Do you really want to clean the states?');
+    const text = translateWord('Do you really want to remove orphaned states?');
     $('#modalclean').find('p').text(text);
     $('#cforce').prop('checked', false);
     $('#cforcediv').removeClass('hide');

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -21,7 +21,7 @@
 <style>
     .m .tabs {
         height: auto!important;
-    }    
+    }
     .m .col .select-wrapper+label, .m .col input+label:not(.active) {
         top: -26px;
     }
@@ -201,6 +201,10 @@
                     </div>
                     <ul id="nav-mobile" class="right">
                         <li>
+                            <a id="state_cleanup_btn" class="btn-floating waves-effect waves-light blue tooltipped center-align hoverable translateT" title="State Cleanup">
+                            <i class="material-icons large icon-blue">sync</i></a>
+                        </li>
+                        <li>
                             <a id="fw_check_btn" class="btn-floating waves-effect waves-light blue tooltipped center-align hoverable translateT" title="Check firmware updates">
                             <i class="material-icons large icon-blue">system_update</i></a>
                         </li>
@@ -220,7 +224,7 @@
                         <li class="tab col s2"><a href="#tab-groups"              class="translate">Groups</a></li>
                         <li class="tab col s2"><a href="#tab-map"  id="tabmap"    class="translate">Network map</a></li>
                         <li class="tab col s2"><a href="#tab-binding"             class="translate">Binding</a></li>
-                        <li class="tab col s2"><a href="#tab-exclude"             class="translate">Excludes</a></li>                        
+                        <li class="tab col s2"><a href="#tab-exclude"             class="translate">Excludes</a></li>
                         <li class="tab col s2"><a href="#tab-sett" id="settings"  class="translate">Settings</a></li>
                         <li class="tab col s2"><a href="#tab-dev"  id="develop"   class="translate">Developer</a></li>
                     </ul>
@@ -324,7 +328,7 @@
                     <div class="input-field col s12 m6 l8">
                         <p class="translate">Tranport Key Text</p>
                     </div>
-                </div>                               
+                </div>
                 <div class="row">
                    <div class="input-field col s12 m6 l8 col-transmitPower">
                         <select id="transmitPower" class="value" >
@@ -335,7 +339,7 @@
                         </select>
                         <label class="translate" for="transmitPower">transmitPower</label>
                     </div>
-                </div>                
+                </div>
                 <div class="row" style="margin-bottom: 90px">
                     <h6>Others</h6>
                     <div class="input-field col s12 m6 l4 col-disableLed">
@@ -346,7 +350,7 @@
                         <input id="disablePing" type="checkbox" class="value" />
                         <label class="translate" for="disablePing">Disable active availability check</label>
                     </div>
-                    
+
                     <div class="input-field col s12 m6 l4 col-disableLed">
                         <input id="debugHerdsman" type="checkbox" class="value" />
                         <label class="translate" for="debugHerdsman">Zigbee-herdsman debug info</label>
@@ -356,7 +360,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <div id="tab-expos" class="col s12 page">
                 <div id="exposes" class="row">
                     <a class="btn-floating waves-effect waves-light blue table-button-add"><i class="material-icons">add</i></a>
@@ -371,7 +375,7 @@
                             </thead>
                         </table>
                     </div>
-                </div>            
+                </div>
             </div>
 
             <div id="tab-dev" class="col s12 page">
@@ -570,7 +574,7 @@
             </div>
             <div id="tab-exclude" class="col s12 page">
                 <div class="col s4">
-                    <p class="translate">ExcludeTextTranslation</p>&nbsp;                        
+                    <p class="translate">ExcludeTextTranslation</p>&nbsp;
                 </div>
                 <div class="fixed-action-btn" style="margin-bottom: 100px">
                     <a id="add_exclude" class="btn-floating waves-effect waves-light blue tooltipped center-align hoverable translateT" title="Add exlude"><i class="material-icons large">add</i></a>
@@ -633,6 +637,20 @@
                 <div id="forcediv" class="hide forcedelete">
                     <input id="force" type="checkbox" class="value" />
                     <label class="translate" for="force">Force delete (for lost devices)</label>
+                </div>
+                <a name="yes" href="#!" class="modal-action modal-close waves-effect waves-green btn green translate">Yes</a>
+                <a href="#!" class="modal-action modal-close waves-effect waves-red btn-flat translate">Cancel</a>
+            </div>
+        </div>
+        <div id="modalclean" class="modal">
+            <div class="modal-content">
+                <h3 class="translate">State cleanup confirmation</h3>
+                <p>A bunch of text</p>
+            </div>
+            <div class="modal-footer">
+                <div id="cforcediv" class="hide cforcedelete">
+                    <input id="cforce" type="checkbox" class="value" />
+                    <label class="translate" for="cforce">Force removed states with custom configuration (history, upnp, etc.)</label>
                 </div>
                 <a name="yes" href="#!" class="modal-action modal-close waves-effect waves-green btn green translate">Yes</a>
                 <a href="#!" class="modal-action modal-close waves-effect waves-red btn-flat translate">Cancel</a>
@@ -754,13 +772,13 @@
             <div class="modal-content">
                 <div class="row">
                     <h3 class="translate">Exclude configuration</h3>
-                    <div class="row">                        
+                    <div class="row">
                         <div class="col s9 input-field">
                             <select id="exclude_target" class="icons">
                             </select>
                             <label for="exclude_target" class="translate">exclude device</label>
-                        </div>                       
-                    </div>                  
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -648,7 +648,7 @@
                 <p>A bunch of text</p>
             </div>
             <div class="modal-footer">
-                <div id="cforcediv" class="hide cforcedelete">
+                <div id="cforcediv" class="hide forcedelete">
                     <input id="cforce" type="checkbox" class="value" />
                     <label class="translate" for="cforce">Force removed states with custom configuration (history, upnp, etc.)</label>
                 </div>

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -77,6 +77,11 @@ class Commands {
                         this.getCoordinatorInfo(obj.from, obj.command, obj.callback);
                     }
                     break;
+                    case 'cleanDeviceStates':
+                    if (obj && obj.message && typeof obj.message === 'object') {
+                        this.cleanDeviceStates(obj.from, obj.command, obj.message, obj.callback);
+                    }
+
                 }
         }
     }
@@ -351,6 +356,19 @@ class Commands {
         } else {
             this.adapter.sendTo(from, command, {error: 'You need to save and start the adapter!'}, callback);
         }
+    }
+
+    async cleanDeviceStates(from, command, msg, callback) {
+        this.info(`State cleanup with ${JSON.stringify(msg)}`);
+        const devicesFromDB = await this.zbController.getClients(false);
+        for (const device of devicesFromDB) {
+            const entity = await this.zbController.resolveEntity(device);
+            if (entity) {
+                const model = (entity.mapped) ? entity.mapped.model : entity.device.modelID;
+                await this.stController.deleteOrphanedDeviceStates(device.ieeeAddr.substr(2), model, msg.force);
+            }
+        }
+        this.adapter.sendTo(from, command, {}, callback);
     }
 
     async getChannels(from, command, message, callback) {

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -2766,7 +2766,8 @@ const devices = [
 
 const commonStates = [
     states.link_quality,
-    states.available
+    states.available,
+    states.device_query,
 ];
 
 const groupStates = [].concat(lightStatesWithColor);

--- a/lib/states.js
+++ b/lib/states.js
@@ -60,14 +60,16 @@ const states = {
         read: true,
         type: 'boolean'
     },
-    checking: { // press button for checking
-        id: 'checking',
-        name: 'Start checking process',
+    device_query: { // press button for checking
+        id: 'device_query',
+        prop: 'device_query',
+        name: 'Trigger device query',
         icon: undefined,
         role: 'button',
         write: true,
         read: false,
         type: 'boolean',
+        isOption: true,
     },
     click: {
         id: 'click',

--- a/lib/states.js
+++ b/lib/states.js
@@ -60,7 +60,7 @@ const states = {
         read: true,
         type: 'boolean'
     },
-    device_query: { // press button for checking
+    device_query: { // button to trigger device read
         id: 'device_query',
         prop: 'device_query',
         name: 'Trigger device query',
@@ -70,6 +70,15 @@ const states = {
         read: false,
         type: 'boolean',
         isOption: true,
+    },
+    checking: { // press button for checking
+        id: 'checking',
+        name: 'Start checking process',
+        icon: undefined,
+        role: 'button',
+        write: true,
+        read: false,
+        type: 'boolean',
     },
     click: {
         id: 'click',

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -11,6 +11,7 @@ class StatesController extends EventEmitter {
         super();
         this.adapter = adapter;
         this.adapter.on('stateChange', this.onStateChange.bind(this));
+        this.query_device_block = [];
     }
 
     info(message, data) {
@@ -110,7 +111,8 @@ class StatesController extends EventEmitter {
         if (!devStates) {
             return;
         }
-        const stateDesc = devStates.states.find((statedesc) => stateKey === statedesc.id);
+        const commonStates = statesMapping.commonStates.find((statedesc) => stateKey === statedesc.id);
+        const stateDesc = (commonStates === undefined ? devStates.states.find((statedesc) => stateKey === statedesc.id) : commonStates);
         const stateModel = devStates.stateModel;
         if (!stateDesc) {
             this.error(`No state available for '${model}' with key '${stateKey}'`);
@@ -170,6 +172,32 @@ class StatesController extends EventEmitter {
             this.adapter.deleteDevice(devId, () => {
                 callback && callback();
             });
+        });
+    }
+
+    async deleteOrphanedDeviceStates(devId, model, force, callback) {
+        const devStates = await this.getDevStates(devId, model);
+        const commonStates = statesMapping.commonStates;
+        this.adapter.getStatesOf(devId, (err, states) => {
+            if (!err && states) {
+                states.forEach((state) => {
+                    let statename = state._id;
+                    const idx = statename.lastIndexOf('.');
+                    if (idx > -1) statename = statename.slice(idx+1);
+                    if (commonStates.find((statedesc) => statename === statedesc.id) === undefined &&
+                       devStates.states.find((statedesc) => statename === statedesc.id) === undefined && statename != 'groups') {
+                       if (state.common.hasOwnProperty('custom') && !force) {
+                           this.info(`keeping disconnected state ${JSON.stringify(statename)} of  ${devId} `);
+                       } else {
+                           this.info(`deleting disconnected state ${JSON.stringify(statename)} of  ${devId} `);
+                           this.adapter.deleteState(devId, null, state._id);
+                       }
+                    }
+                    else {
+                        ///this.warn(`keeping connecte state ${JSON.stringify(statename)} of  ${devId} `);
+                    }
+                });
+            }
         });
     }
 
@@ -294,7 +322,8 @@ class StatesController extends EventEmitter {
             if (!states.hasOwnProperty(stateInd)) continue;
 
             const statedesc = states[stateInd];
-
+            if (statedesc === undefined)
+               this.error(`syncDevStates: Illegal state in ${dev} -  ${JSON.stringify(stateInd)}`);
             // Filter out non routers or devices that are battery driven for the availability flag
             if (statedesc.id === 'available')
                 if (!(dev.type === 'Router') || dev.powerSource === 'Battery')

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -22,6 +22,9 @@ const forcedPingable = [
 // in mired and Kelvin.
 const toZigbeeCandidates = ['local_temperature','state', 'brightness']; //, 'color', 'color_temp'];
 const Hours25 = 1000 * 60 * 60 * 25;
+const MinAvailabilityTimeout = 300; // ping every 5 minutes with few devices
+const MaxAvailabilityTimeout = 1800; // ping every 30 minutes with many devices;
+const AverageTimeBetweenPings = 45; // on average, plan for 30 seconds between pings.
 
 /**
  * This extensions pings devices to check if they are online.
@@ -36,6 +39,7 @@ class DeviceAvailability extends BaseExtension {
         this.state = {};
         this.active_ping = true;
         this.forced_ping = true;
+        this.number_of_registered_devices = 0;
         // force publish availability for new devices
         this.zigbee.on('new', (entity) => {
             // wait for 1s for creating device states
@@ -83,6 +87,8 @@ class DeviceAvailability extends BaseExtension {
             if (item && item.device == device)
                 return;
         });
+        this.number_of_registered_devices++;
+        this.availability_timeout = Math.max(Math.min(this.number_of_registered_devices * AverageTimeBetweenPings,MaxAvailabilityTimeout ),MinAvailabilityTimeout);
         this.startDevicePingQueue.push({device:device, entity:entity});
         if (this.startDevicePingTimeout == null)
             this.startDevicePingTimeout = setTimeout(async() => {
@@ -134,7 +140,10 @@ class DeviceAvailability extends BaseExtension {
         }
         if (this.isPingable(device)) {
             let pingCount = this.ping_counters[device.ieeeAddr];
-            if (pingCount === undefined) pingCount = 0;
+            if (pingCount === undefined) {
+                this.ping_counters[device.ieeeAddr] = { failed: 0, reported: 0};
+                pingCount = { failed: 0, reported: 0};
+            }
 
             // first see if we can "ping" the device by reading a Status
             try {
@@ -144,7 +153,7 @@ class DeviceAvailability extends BaseExtension {
                         await converter.convertGet(device.endpoints[0], key, {});
                         this.debug(`Successful read state '${key}' of '${device.ieeeAddr}' in stead of pinging`);
                         this.setTimerPingable(device, 1);
-                        this.ping_counters[device.ieeeAddr] = 0;
+                        this.ping_counters[device.ieeeAddr].failed = 0;
                         return;
                     }
                 }
@@ -159,20 +168,23 @@ class DeviceAvailability extends BaseExtension {
                 this.publishAvailability(device, true);
                 this.debug(`Successfully pinged ${ieeeAddr} ${device.modelID}`);
                 this.setTimerPingable(device, 1);
-                this.ping_counters[device.ieeeAddr] = 0;
+                this.ping_counters[device.ieeeAddr].failed = 0;
             } catch (error) {
                 this.publishAvailability(device, false);
-                if (pingCount++ <= this.max_ping)
+                if (pingCount.failed++ <= this.max_ping)
                 {
-                    if (pingCount < 2)
+                    if (pingCount.failed < 2 && pingCount.reported < this.max_ping) {
                         this.warn(`Failed to ping ${ieeeAddr} ${device.modelID}`);
-                    else
+                        pingCount.reported++;
+                    }
+                    else {
                         this.debug(`Failed to ping ${ieeeAddr} ${device.modelID} on ${pingCount} consecutive attempts`);
-                    this.setTimerPingable(device, pingCount);
-                    this.ping_counters[device.ieeeAddr] = pingCount;
+                    }
+                    this.setTimerPingable(device, pingCount.failed);
+                    this.ping_counters[device.ieeeAddr]= pingCount;
                 }
                 else {
-                    this.warn(`Stopping to ping ${ieeeAddr} ${device.modelID} after ${pingCount} ping attempts`);
+                    this.warn(`Stopping to ping ${ieeeAddr} ${device.modelID} after ${pingCount.failed} ping attempts`);
                 }
             }
         }
@@ -252,6 +264,21 @@ class DeviceAvailability extends BaseExtension {
         }
     }
 
+    async triggerDeviceQuery(device, states) {
+        const entity = await this.zigbee.resolveEntity(device);
+        if (entity && entity.mapped) {
+            for (const converter of entity.mapped.toZigbee) {
+                try {
+                    if (converter.hasOwnProperty(convertGet)) {
+                        await converter.convertGet(device.endpoints[0], key, {});
+                    }
+                } catch (error) {
+                    this.debug(`Failed to read state of '${entity.device.ieeeAddr}' after reconnect`);
+                }
+            }
+        }
+    }
+
     onZigbeeEvent(data) {
         const device = data.device;
         if (!device) {
@@ -264,7 +291,13 @@ class DeviceAvailability extends BaseExtension {
             // When a zigbee message from a device is received we know the device is still alive.
             // => reset the timer.
             this.setTimerPingable(device, 1);
-            this.ping_counters[device.ieeeAddr] = 0;
+            const pc = this.ping_counters[device.ieeeAddr];
+            if (pc == undefined) {
+                this.ping_counters[device.ieeeAddr] = { failed:0, reported:0}
+            }
+            else {
+                this.ping_counters[device.ieeeAddr].failed++;
+            }
 
             const online = this.state.hasOwnProperty(device.ieeeAddr) && this.state[device.ieeeAddr];
             if (online && data.type === 'deviceAnnounce' && !utils.isIkeaTradfriDevice(device)) {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -212,6 +212,7 @@ class ZigbeeController extends EventEmitter {
         }
     }
 
+
     getDevice(key) {
         return this.herdsman.getDeviceByIeeeAddr(key);
     }


### PR DESCRIPTION
- Modification on 'failed ping' messages
- New state for each device: Device query as button. Activation triggers a 'convertGet' for each converter which has one. 'Spam' protection limits activation to once every 10 seconds. **Note** Use of this may generate warning messages for cases where a state receives an object which is not parsed in a getter.
- Orphaned state removal: 4th button on the top right: Refresh icon. Can be used to remove any state which is no longer linked to the model definition. Does exclude 'groups' and  the states defined as commonstates (available, link_quality, device_query). Default will not delete any state which has a custom configuration (history, etc.) The force checkbox will override this.
- Ping timeout no longer fixed at 5 minutes: Time between pings for a device is calculated by 'number of devices to ping * 45 seconds, with a minimum of 5 minutes and a maximum of 30 minutes. 