### PR TITLE
device specific message capture

### DIFF
--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -149,7 +149,7 @@ class StatesController extends EventEmitter {
         if (this.debugDevices === undefined) this.getDebugDevices();
         this.debug(`Change state '${stateKey}' at device ${deviceId} type '${model}'`);
         for (const addressPart of this.debugDevices) {
-            if (id.indexOf(addressPart) > -1)
+            if (deviceId.indexOf(addressPart) > -1)
             {
                 this.debug(`ELEVATED Change state '${stateKey}' at device ${deviceId} type '${model}'`);
                 break;

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -12,6 +12,7 @@ class StatesController extends EventEmitter {
         this.adapter = adapter;
         this.adapter.on('stateChange', this.onStateChange.bind(this));
         this.query_device_block = [];
+        this.debugDevices = undefined;
     }
 
     info(message, data) {
@@ -30,9 +31,48 @@ class StatesController extends EventEmitter {
         this.emit('log', 'warn', message, data);
     }
 
+    getDebugDevices() {
+        this.adapter.getState(this.adapter.namespace + '.info.debugmessages', (err, state) => {
+            if (err) return;
+            this.debugDevices = [];
+            if (state) {
+                if (typeof(state.val) == 'string' && state.val.length > 2) this.debugDevices = state.val.split(';');
+                this.info('debug devices set to ' + JSON.stringify(this.debugDevices));
+            } else {
+                this.adapter.setObject('info.debugmessages', {    "type": "state",
+                                                                  "common": {
+                                                                    "name": "Log changes as warnings for",
+                                                                    "role": "",
+                                                                    "type": "string",
+                                                                    "read": true,
+                                                                    "write": true,
+                                                                  },
+                                                                  "native": {},
+                                                              });
+
+            }
+        });
+
+    }
     onStateChange(id, state){
+        if (this.debugDevices === undefined) this.getDebugDevices();
         if (state && !state.ack) {
             if (id.endsWith('pairingCountdown') || id.endsWith('pairingMessage') || id.endsWith('connection')) return;
+            if (id.endsWith('debugmessages')) {
+                if  (typeof(state.val) == 'string' && state.val.length > 2)
+                    this.debugDevices = state.val.split(';');
+                else {
+                    this.debugDevices = [];
+                }
+                return;
+            }
+            for (const addressPart of this.debugDevices) {
+                if (id.indexOf(addressPart) > -1)
+                {
+                    this.warn(`ELEVATED: User stateChange ${id} ${JSON.stringify(state)}`)
+                    break;
+                }
+            }
             this.debug(`User stateChange ${id} ${JSON.stringify(state)}`);
             const devId = getAdId(this.adapter, id); // iobroker device id
             let deviceId = getZbId(id); // zigbee device id
@@ -106,7 +146,15 @@ class StatesController extends EventEmitter {
     }
 
     async publishFromState(deviceId, model, stateKey, state, options) {
+        if (this.debugDevices === undefined) this.getDebugDevices();
         this.debug(`Change state '${stateKey}' at device ${deviceId} type '${model}'`);
+        for (const addressPart of this.debugDevices) {
+            if (id.indexOf(addressPart) > -1)
+            {
+                this.debug(`ELEVATED Change state '${stateKey}' at device ${deviceId} type '${model}'`);
+                break;
+            }
+        }
         const devStates = await this.getDevStates(deviceId, model);
         if (!devStates) {
             return;
@@ -355,6 +403,16 @@ class StatesController extends EventEmitter {
 
     async publishToState(devId, model, payload) {
         const devStates = await this.getDevStates('0x'+devId, model);
+        let has_debug=false;
+        if (this.debugDevices === undefined) this.getDebugDevices();
+        for (const addressPart of this.debugDevices) {
+            if (devId == addressPart || devId.indexOf(addressPart) > -1)
+            {
+                this.warn(`ELEVATED publishToState: message received '${JSON.stringify(payload)}' from device ${devId} type '${model}'`);
+                has_debug = true;
+                break;
+            }
+        }
         if (!devStates) {
             return;
         }
@@ -373,6 +431,10 @@ class StatesController extends EventEmitter {
                 }
                 // checking value
                 if (value === undefined) continue;
+
+                if (has_debug) {
+                    this.warn(`ELEVATED publishToState: value generated '${JSON.stringify(value)}' from device ${devId} for '${statedesc.name}'`);
+                }
 
                 const common = {
                     name: statedesc.name,


### PR DESCRIPTION
Setting the new state 'debugmessages' to the IEEE of a device (or part of it), the adapter will elevate messages when changing states or receiving zigbee messages to "warn" level, so they can be read in the log without enabling adapter wide debug

this can be changed while the adapter is running.