### PR TITLE
Support extended functionality of zigbee-herdsman-converters without state

### DIFF
--- a/lib/states.js
+++ b/lib/states.js
@@ -69,8 +69,6 @@ const states = {
         read: true,
         type: 'string',
         isOption: true,
-        setter: (value, options) => {
-        },
     },
     link_quality: {
         id: 'link_quality',

--- a/lib/states.js
+++ b/lib/states.js
@@ -84,16 +84,6 @@ const states = {
         min: 0,
         max: 254
     },
-    raw_payload: {
-        id: 'raw_payload',
-        prop: 'dynamic',
-        name: 'raw Payload',
-        icon: undefined,
-        role: 'state',
-        write: true,
-        read: false,
-        type: string,
-    }
     available: {
         id: 'available',
         prop: 'available',

--- a/lib/states.js
+++ b/lib/states.js
@@ -69,6 +69,8 @@ const states = {
         read: true,
         type: 'string',
         isOption: true,
+        setter: (value, options) => {
+        },
     },
     link_quality: {
         id: 'link_quality',
@@ -82,6 +84,16 @@ const states = {
         min: 0,
         max: 254
     },
+    raw_payload: {
+        id: 'raw_payload',
+        prop: 'dynamic',
+        name: 'raw Payload',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: false,
+        type: string,
+    }
     available: {
         id: 'available',
         prop: 'available',

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -178,29 +178,50 @@ class StatesController extends EventEmitter {
         const value = state.val;
         if (value === undefined || value === '')
             return;
-
-        let stateList = [{stateDesc: stateDesc, value: value, index: 0, timeout: 0}];
-        if (stateModel && stateModel.linkedStates) {
-            stateModel.linkedStates.forEach((linkedFunct) => {
-                try {
-                    if (typeof linkedFunct === 'function') {
-                        const res = linkedFunct(stateDesc, value, options, this.adapter.config.disableQueue);
-                        if (res) {
-                            stateList = stateList.concat(res);
-                        }
+        let stateList = [];
+        if (stateKey === 'raw_payload') {
+            try {
+                const json_value = JSON.parse(value)
+                for (var key in json_value) {
+                    if (json_value[key]) {
+                        const datatype = typeof json_value[key];
+                        statelist.push({stateDesc: {
+                            id:key,
+                            prop:key,
+                            role:'state',
+                            type:datatype,
+                        }, value: json_value[key], index:0, timeout:0})
                     }
-                    else {
-                        this.warn('publish from State - LinkedState is not a function ' + JSON.stringify(linkedFunct));
-                    }
-                } catch (e) {
-                    this.error('Exception caught in publishfromstate');
                 }
+            }
+            catch {
+                this.warn(`Illegal json string in raw_payload for '${model}' with key '${stateKey}'`)
+            }
 
-            });
-            // sort by index
-            stateList.sort((a, b) => {
-                return a.index - b.index;
-            });
+        } else {
+            stateList.push({stateDesc: stateDesc, value: value, index: 0, timeout: 0});
+            if (stateModel && stateModel.linkedStates) {
+                stateModel.linkedStates.forEach((linkedFunct) => {
+                    try {
+                        if (typeof linkedFunct === 'function') {
+                            const res = linkedFunct(stateDesc, value, options, this.adapter.config.disableQueue);
+                            if (res) {
+                                stateList = stateList.concat(res);
+                            }
+                        }
+                        else {
+                            this.warn('publish from State - LinkedState is not a function ' + JSON.stringify(linkedFunct));
+                        }
+                    } catch (e) {
+                        this.error('Exception caught in publishfromstate');
+                    }
+
+                });
+                // sort by index
+                stateList.sort((a, b) => {
+                    return a.index - b.index;
+                });
+            }
         }
 
         // holds the states for for read after write requests

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -179,49 +179,28 @@ class StatesController extends EventEmitter {
         if (value === undefined || value === '')
             return;
         let stateList = [];
-        if (stateKey === 'raw_payload') {
-            try {
-                const json_value = JSON.parse(value)
-                for (var key in json_value) {
-                    if (json_value[key]) {
-                        const datatype = typeof json_value[key];
-                        statelist.push({stateDesc: {
-                            id:key,
-                            prop:key,
-                            role:'state',
-                            type:datatype,
-                        }, value: json_value[key], index:0, timeout:0})
+        stateList.push({stateDesc: stateDesc, value: value, index: 0, timeout: 0});
+        if (stateModel && stateModel.linkedStates) {
+            stateModel.linkedStates.forEach((linkedFunct) => {
+                try {
+                    if (typeof linkedFunct === 'function') {
+                        const res = linkedFunct(stateDesc, value, options, this.adapter.config.disableQueue);
+                        if (res) {
+                            stateList = stateList.concat(res);
+                        }
                     }
+                    else {
+                        this.warn('publish from State - LinkedState is not a function ' + JSON.stringify(linkedFunct));
+                    }
+                } catch (e) {
+                    this.error('Exception caught in publishfromstate');
                 }
-            }
-            catch {
-                this.warn(`Illegal json string in raw_payload for '${model}' with key '${stateKey}'`)
-            }
 
-        } else {
-            stateList.push({stateDesc: stateDesc, value: value, index: 0, timeout: 0});
-            if (stateModel && stateModel.linkedStates) {
-                stateModel.linkedStates.forEach((linkedFunct) => {
-                    try {
-                        if (typeof linkedFunct === 'function') {
-                            const res = linkedFunct(stateDesc, value, options, this.adapter.config.disableQueue);
-                            if (res) {
-                                stateList = stateList.concat(res);
-                            }
-                        }
-                        else {
-                            this.warn('publish from State - LinkedState is not a function ' + JSON.stringify(linkedFunct));
-                        }
-                    } catch (e) {
-                        this.error('Exception caught in publishfromstate');
-                    }
-
-                });
-                // sort by index
-                stateList.sort((a, b) => {
-                    return a.index - b.index;
-                });
-            }
+            });
+            // sort by index
+            stateList.sort((a, b) => {
+                return a.index - b.index;
+            });
         }
 
         // holds the states for for read after write requests

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -178,8 +178,7 @@ class StatesController extends EventEmitter {
         const value = state.val;
         if (value === undefined || value === '')
             return;
-        let stateList = [];
-        stateList.push({stateDesc: stateDesc, value: value, index: 0, timeout: 0});
+        let stateList = [{stateDesc: stateDesc, value: value, index: 0, timeout: 0}];
         if (stateModel && stateModel.linkedStates) {
             stateModel.linkedStates.forEach((linkedFunct) => {
                 try {

--- a/main.js
+++ b/main.js
@@ -578,14 +578,17 @@ class Zigbee extends utils.Adapter {
                 let stateList = [];
                 const entity = await this.zbController.resolveEntity(`0x${payload.device}`);
                 if (!entity) {
-                    this.log.error(`Device ${safeJsonStringify(payload_obj.device)} not found`)
+                    this.log.error(`Device ${safeJsonStringify(payload_obj.device)} not found`);
+                    return {success: false, error: `Device ${safeJsonStringify(payload_obj.device)} not found`};
                 }
                 const mappedModel = entity.mapped;
                 if (!mappedModel) {
-                    this.log.error(`No Model for Device ${safeJsonStringify(payload_obj.device)}`)
+                    this.log.error(`No Model for Device ${safeJsonStringify(payload_obj.device)}`);
+                    return {success: false, error: `No Model for Device ${safeJsonStringify(payload_obj.device)}`};
                 }
                 if (typeof payload_obj.payload !== 'object') {
-                    this.log.error(`Illegal payload type for ${safeJsonStringify(payload_obj.device)}`)
+                    this.log.error(`Illegal payload type for ${safeJsonStringify(payload_obj.device)}`);
+                    return {success: false, error: `Illegal payload type for ${safeJsonStringify(payload_obj.device)}`};
                 }
                 for (var key in payload_obj.payload) {
                     if (payload_obj.payload[key] != undefined) {
@@ -608,15 +611,15 @@ class Zigbee extends utils.Adapter {
                 {
                     this.filterError(`Error ${error.code} on send command to ${payload.device}.`+
                        ` Error: ${error.stack}`, `Send command to ${payload.device} failed with`, error);
-                    return {success:false, error: error, loc:1};
+                    return {success:false, error: error};
                 }
             }
             catch (e) {
-                return {success:false, error: e, loc:2};
+                return {success:false, error: e};
             }
 
         }
-        return {success:false, error: 'missing parameter device or payload in message ' + JSON.stringify(payload), loc:3};
+        return {success:false, error: 'missing parameter device or payload in message ' + JSON.stringify(payload)};
     }
 
 

--- a/main.js
+++ b/main.js
@@ -87,7 +87,6 @@ class Zigbee extends utils.Adapter {
         if (typeof obj === 'object' && obj.command) {
             switch (obj.command) {
                 case 'SendToDevice':
-                this.log.warn(`on Message: ${JSON.stringify(obj)}`)
                 let rv = {
                     success: false,
                     loc:-1,
@@ -438,7 +437,6 @@ class Zigbee extends utils.Adapter {
     }
 
     async publishFromState(deviceId, model, stateModel, stateList, options){
-        this.log.debug(`State changes. dev: ${deviceId} model: ${model} states: ${safeJsonStringify(stateList)} opt: ${safeJsonStringify(options)}`);
         if (model == 'group') {
             deviceId = parseInt(deviceId);
         }
@@ -497,7 +495,6 @@ class Zigbee extends utils.Adapter {
 
             const preparedValue = (stateDesc.setter) ? stateDesc.setter(value, options) : value;
             const preparedOptions = (stateDesc.setterOpt) ? stateDesc.setterOpt(value, options) : {};
-
             let syncStateList = [];
             if (stateModel && stateModel.syncStates) {
                 stateModel.syncStates.forEach((syncFunct) => {
@@ -536,7 +533,8 @@ class Zigbee extends utils.Adapter {
                 const result = await converter.convertSet(target, key, preparedValue, meta);
                 this.log.debug(`convert result ${safeJsonStringify(result)}`);
 
-                this.acknowledgeState(deviceId, model, stateDesc, value);
+                if (stateModel)
+                    this.acknowledgeState(deviceId, model, stateDesc, value);
                 // process sync state list
                 this.processSyncStatesList(deviceId, model, syncStateList);
             } catch(error) {
@@ -583,7 +581,6 @@ class Zigbee extends utils.Adapter {
                     this.log.error(`Device ${safeJsonStringify(payload_obj.device)} not found`)
                 }
                 const mappedModel = entity.mapped;
-                this.log.warn('Mapped Model: ' +  JSON.stringify(mappedModel));
                 if (!mappedModel) {
                     this.log.error(`No Model for Device ${safeJsonStringify(payload_obj.device)}`)
                 }
@@ -691,7 +688,6 @@ class Zigbee extends utils.Adapter {
     }
 
     getZigbeeOptions() {
-        this.log.warn('get Zigbee Options called')
         // file path for db
         const dataDir = (this.systemConfig) ? this.systemConfig.dataDir : '';
         const dbDir = pathLib.normalize(utils.controllerDir + '/' + dataDir + this.namespace.replace('.', '_'));


### PR DESCRIPTION
Introduce a message function which can be called using the sendTo command from ioBroker user scripts.

Syntax: 

sendTo('zigbee.0', 'SendToDevice', {'device':'bc33acfffe5ec8bb', 'payload':{'brightness_move':10}}, function(res) {
   if (res.success) console.log("success") else console.log(res.error);
});

This will offer access to a number of device specific configurations (e.g. "remember_state" on Osram bulbs, "brightness_move" on most bulbs, etc.)

Only functions which are made available through converters at specific devices are supported.