### PR TITLE
model name changed

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1492,7 +1492,7 @@ const devices = [
         states: [],
     },
     {
-        models: ['E1525/E1745'],
+        models: ['E1525_E1745'],
         icon: 'img/ikea_motion_sensor.png',
         states: [states.occupancy, states.battery, states.no_motion]
     },


### PR DESCRIPTION
replaces slash against underscore, otherwise link from device tile not working