### PR TITLE
Replace '/' with '_' in device types when generating card links

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -192,7 +192,7 @@ function getGroupCard(dev) {
 function getCard(dev) {
     const title = dev.common.name,
         id = dev._id,
-        type = dev.common.type,
+        type = dev.common.type.replace('/','_'),
         img_src = dev.icon || dev.common.icon,
         rooms = [],
         lang = systemLang  || 'en';


### PR DESCRIPTION
Attempt to fix wrong link for E1525/E1745 (Issue #392 