### PR TITLE
Bugfix

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -192,7 +192,7 @@ function getGroupCard(dev) {
 function getCard(dev) {
     const title = dev.common.name,
         id = dev._id,
-        type = dev.common.type,
+        type = dev.common.type.replace('/','_'),
         img_src = dev.icon || dev.common.icon,
         rooms = [],
         lang = systemLang  || 'en';

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -393,27 +393,33 @@ class ZigbeeController extends EventEmitter {
         } else {
             this.info('Zigbee: disabling joining new devices.');
         }
-
-        if (permitTime && !this.herdsman.getPermitJoin()) {
-            clearInterval(this._permitJoinInterval);
-            this._permitJoinTime = permitTime;
-            await this.herdsman.permitJoin(true, permitDev);
-            this._permitJoinInterval = setInterval(async () => {
-                this.emit('pairing', 'Pairing time left', this._permitJoinTime);
-                if (this._permitJoinTime === 0) {
-                    this.info('Zigbee: stop joining');
-                    clearInterval(this._permitJoinInterval);
-                    await this.herdsman.permitJoin(false);
-                }
-                this._permitJoinTime -= 1;
-            }, 1000);
-        } else if (this.herdsman.getPermitJoin()) {
-            if (permitTime) {
-                this.info('Joining already permitted');
-            } else {
+        try
+        {
+            if (permitTime && !this.herdsman.getPermitJoin()) {
                 clearInterval(this._permitJoinInterval);
-                await this.herdsman.permitJoin(false, permitDev);
+                this._permitJoinTime = permitTime;
+                await this.herdsman.permitJoin(true, permitDev);
+                this._permitJoinInterval = setInterval(async () => {
+                    this.emit('pairing', 'Pairing time left', this._permitJoinTime);
+                    if (this._permitJoinTime === 0) {
+                        this.info('Zigbee: stop joining');
+                        clearInterval(this._permitJoinInterval);
+                        await this.herdsman.permitJoin(false);
+                    }
+                    this._permitJoinTime -= 1;
+                }, 1000);
+            } else if (this.herdsman.getPermitJoin()) {
+                if (permitTime) {
+                    this.info('Joining already permitted');
+                } else {
+                    clearInterval(this._permitJoinInterval);
+                    await this.herdsman.permitJoin(false, permitDev);
+                }
             }
+        }
+        catch (e)
+        {
+            this.error(`Failed to open the network: ${e.stack}`)
         }
     }
 


### PR DESCRIPTION
- Replace '\' with '_' in device names when generating links  - issue #1069
- Catch error when herdsman refuses to open network and throws an error