### PR TITLE
Update Innr SP 120 to support Plug Voltage

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1616,7 +1616,12 @@ const devices = [
         linkedStates: [comb.brightnessAndState],
     },
     {
-        models: ['SP 120', 'SP 220', 'SP 222', 'SP 224'],
+        models: ['SP 120'],
+        icon: 'img/innr_plug.png',
+        states: [states.state,states.load_power,states.plug_voltage],
+    },
+    {
+        models: ['SP 220', 'SP 222', 'SP 224'],
         icon: 'img/innr_plug.png',
         states: [states.state,states.load_power],
     },


### PR DESCRIPTION
adding states.plug_voltage to the Innr SP120 Device
maybe it can be enabled for the other SP XXX Devices too, but i don't have them, i can not check.