### PR TITLE
Add Tuya Smart air box sensor

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -2541,6 +2541,10 @@ const devices = [
         states: [states.state, states.plug_summdelivered, states.load_current, states.plug_voltage, states.load_power],
     },
     {
+        models: ['TS0601_air_quality_sensor'],
+        states: [states.temperature, states.humidity, states.co2, states.voc],
+    },
+    {
         models: ['TS0601_thermostat'],
         icon: 'img/tuya_TS0601.png',
         states: [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "zigbee-herdsman": "0.13.102",
-    "zigbee-herdsman-converters": "14.0.149",
+    "zigbee-herdsman-converters": "14.0.156",
     "@iobroker/adapter-core": "^2.4.0",
     "tar": "^6.0.5",
     "typescript": "^4.0.5"


### PR DESCRIPTION
Adds support for tuya smart air box sensor 
see also: https://github.com/Koenkk/zigbee-herdsman-converters/pull/2612
Closes #1107  