### PR TITLE
Update devices.js

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -765,11 +765,6 @@ const devices = [
         states: [states.state, states.load_power, states.plug_voltage, states.plug_consumption, states.plug_temperature],
     },
     {
-        models: ['LLKZMK11LM'],
-        icon: 'img/lumi.relay.c2acn01.png',
-        states: [states.state, states.load_power, states.plug_voltage, states.plug_consumption],
-    },
-    {
         models: ['QBCZ11LM'],
         icon: 'img/86plug.png',
         states: [states.state, states.load_power, states.plug_voltage, states.plug_consumption, states.plug_temperature],
@@ -822,7 +817,7 @@ const devices = [
         models: ['LLKZMK11LM'],
         icon: 'img/lumi_relay.png',
         states: [states.channel1_state, states.channel2_state, states.load_power,
-            states.temperature, states.interlock],
+            states.temperature, states.interlock, states.plug_consumption],
     },
     {
         models: ['ZNCLDJ11LM'],


### PR DESCRIPTION
There was a double definition for LLKZMK11LM:

 {
        models: ['LLKZMK11LM'],
        icon: 'img/lumi.relay.c2acn01.png',
        states: [states.state, states.load_power, states.plug_voltage, states.plug_consumption],
    },
and this one:
    {
        models: ['LLKZMK11LM'],
        icon: 'img/lumi_relay.png',
        states: [states.channel1_state, states.channel2_state, states.load_power,
                 states.temperature, states.interlock],
    }
Second one has had no consumption.