### PR TITLE
Change CI matrix for node - exclude 10.x, as the support is dropped by ioBroker.js-controller (newest version 3.4.0 => 4.0.0)

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
         os: [ubuntu-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
To make the CI tests working, as the **master** branch of JS-Controller is hardcoded it _ioBroker/testing_, and has new dependency, which exclude node 10.x
And node 16.x test is added  for the future compatibility.