### PR TITLE
Add additional keys to log on error and possibility to debug complex …

### DIFF
--- a/main.js
+++ b/main.js
@@ -493,7 +493,7 @@ class Zigbee extends utils.Adapter {
             }
             const converter = mappedModel.toZigbee.find((c) => c && (c.key.includes(stateDesc.prop) || c.key.includes(stateDesc.setattr) || c.key.includes(stateDesc.id)));
             if (!converter) {
-                this.log.error(`No converter available for '${model}' with key '${stateDesc.id}' `);
+                this.log.error(`No converter available for '${model}' with keys: prop = '${stateDesc.prop}', setattr = '${stateDesc.setattr}', id = '${stateDesc.id}' `);
                 return;
             }
 
@@ -511,7 +511,7 @@ class Zigbee extends utils.Adapter {
 
             const epName = stateDesc.epname !== undefined ? stateDesc.epname : (stateDesc.prop || stateDesc.id);
             const key = stateDesc.setattr || stateDesc.prop || stateDesc.id;
-            this.log.debug(`convert ${key}, ${preparedValue}, ${safeJsonStringify(preparedOptions)}`);
+            this.log.debug(`convert ${key}, ${safeJsonStringify(preparedValue)}, ${safeJsonStringify(preparedOptions)}`);
 
             let target;
             if (model === 'group') {


### PR DESCRIPTION
…value

On branch extended_error_and_debug_log_on_converter

Added additional keys, used for converter search, to make error message more understandale
when the state have not only `.id` in 'keys'.

Added converstion to string for value in debug, to make possible see more details for
object values ...

 Changes to be committed:
	modified:   main.js