### PR TITLE
Added processing xiaomi curtains options (reverse_direction, hand_open, reset_limits)

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -822,7 +822,8 @@ const devices = [
     {
         models: ['ZNCLDJ11LM'],
         icon: 'img/aqara_curtain.png',
-        states: [states.curtain_position, states.curtain_running, states.curtain_stop],
+        states: [states.curtain_position, states.curtain_running, states.curtain_stop, states.curtain_xiaomi_reverse_direction,
+        states.curtain_xiaomi_reset_limits, states.curtain_xiaomi_hand_open],
     },
     {
         models: ['WXCJKG11LM'],

--- a/lib/states.js
+++ b/lib/states.js
@@ -2943,6 +2943,9 @@ const states = {
         type: 'boolean',
         inOptions: true,
         getter: payload => (payload.options !== null) && payload.options.hasOwnProperty('reverse_direction') && !isNaN(payload.options.reverse_direction) ? payload.options.reverse_direction : undefined,
+        setterOpt: (value, options) => {
+            return {...options, reverse_direction: value};
+        },
         setter: (value, options) => {
             return {...options, reverse_direction: value};
         },
@@ -2958,6 +2961,9 @@ const states = {
         type: 'boolean',
         inOptions: true,
         getter: payload => (payload.options !== null) && payload.options.hasOwnProperty('hand_open') && !isNaN(payload.options.hand_open) ? payload.options.hand_open : undefined,
+        setterOpt: (value, options) => {
+            return {...options, hand_open: value};
+        },
         setter: (value, options) => {
             return {...options, hand_open: value};
         },

--- a/lib/states.js
+++ b/lib/states.js
@@ -2932,6 +2932,51 @@ const states = {
             return {...options, reverse_direction: value};
         },
     },
+    curtain_xiaomi_reverse_direction: {
+        id: 'reverse_direction',
+        prop: 'options',
+        name: 'Reverse direction',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'boolean',
+        inOptions: true,
+        getter: payload => (payload.options !== null) && payload.options.hasOwnProperty('reverse_direction') && !isNaN(payload.options.reverse_direction) ? payload.options.reverse_direction : undefined,
+        setter: (value, options) => {
+            return {...options, reverse_direction: value};
+        },
+    },
+    curtain_xiaomi_hand_open: {
+        id: 'hand_open',
+        prop: 'options',
+        name: 'Hand open',
+        icon: undefined,
+        role: 'state',
+        write: true,
+        read: true,
+        type: 'boolean',
+        inOptions: true,
+        getter: payload => (payload.options !== null) && payload.options.hasOwnProperty('hand_open') && !isNaN(payload.options.hand_open) ? payload.options.hand_open : undefined,
+        setter: (value, options) => {
+            return {...options, hand_open: value};
+        },
+    },
+    curtain_xiaomi_reset_limits: {
+        id: 'reset_limits',
+        prop: 'options',
+        name: 'Reset limits',
+        icon: undefined,
+        role: 'button',
+        write: true,
+        read: true,
+        type: 'boolean',
+        isEvent: true,
+        inOptions: true,
+        setter: (value, options) => {
+            return {...options, reset_limits: value};
+        },
+    },
     blind_position: {
         id: 'position',
         prop: 'position',


### PR DESCRIPTION
It has object construction in `herdsman-converters`
```
options {
    reverse_direction: boolean,
    hand_open: boolean,
    reset_limits: boolean
}
```
as for fromZigbee, as for toZigbee ...

So, we need to process it as object in both cases - for getter ans setter.
`reset_limits` isn't returned, and marked as Event and button.
Appropriate request for the herdsman-converters to make an exposes in upcoming.
