### PR TITLE
Exposes composite enchancements

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -147,12 +147,12 @@ function createFromExposes(model, def) {
         else {
             if ( (state.readable) && (! this[stateExists].readable ) ) {
                 this[stateExists].read = state.read;
-                // as state is readable, it can't be button or action
+                // as state is readable, it can't be button or event
                 if (this[stateExists].role === 'button') {
                     this[stateExists].role = state.role;
                 }
-                if (this[stateExists].hasOwnProperty('isAction')) {
-                    this[stateExists].isAction = false;
+                if (this[stateExists].hasOwnProperty('isEvent')) {
+                    delete this[stateExists].isEvent;
                 }
                 // we have to use the getter from "new" state
                 if ( state.hasOwnProperty('getter') ) {

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -5,11 +5,15 @@ const statesDefs = require(__dirname + '/states.js').states;
 const rgb = require(__dirname + '/rgb.js');
 const utils = require(__dirname + '/utils.js');
 const colors = require(__dirname + '/colors.js');
+const ea = zigbeeHerdsmanConverters.exposes.access;
 
 function genState(expose, role, name, desc) {
     let state;
+    console.log(`expose = ${JSON.stringify(expose)} role = ${JSON.stringify(role)} name =  ${JSON.stringify(name)}  desc =  ${JSON.stringify(desc)}`);
     // write if access.SET or access.STATE_SET or access.ALL
-    const write = [2, 3, 7].includes(expose.access);
+    //const write = [2, 3, 7].includes(expose.access);
+    const readable = (expose.access & ea.STATE) > 0;
+    const writable = (expose.access & ea.SET) > 0;
     const stateId = (name || expose.property).replace(/\*/g, '');
     const stateName = (desc || expose.description || expose.name);
     const propName = expose.property;
@@ -21,13 +25,20 @@ function genState(expose, role, name, desc) {
                 name: stateName,
                 icon: undefined,
                 role: role || 'state',
-                write: write,
-                read: true,
+                write: writable,
+                read: readable,
                 type: 'boolean',
-                getter: payload => (payload[propName] === (expose.value_on || 'ON')),
-                setter: (value) => (value) ? (expose.value_on || 'ON') : ((expose.value_off != undefined) ? expose.value_off : 'OFF'),
-                setattr: expose.name,
             };
+            if (readable) {
+                state.getter = payload => (payload[propName] === (expose.value_on || 'ON'));
+            }
+            else {
+                state.role = 'button';
+            }
+            if (writable) {
+                state.setter = (value) => (value) ? (expose.value_on || 'ON') : ((expose.value_off != undefined) ? expose.value_off : 'OFF');
+                state.setattr = expose.name;
+            }
             if (expose.endpoint) {
                 state.epname = expose.endpoint;
             }
@@ -40,7 +51,7 @@ function genState(expose, role, name, desc) {
                 name: stateName,
                 icon: undefined,
                 role: role || 'state',
-                write: write,
+                write: writable,
                 read: true,
                 type: 'number',
                 min: expose.value_min || 0,
@@ -59,7 +70,7 @@ function genState(expose, role, name, desc) {
                 name: stateName,
                 icon: undefined,
                 role: role || 'state',
-                write: write,
+                write: writable,
                 read: true,
                 type: 'string',
                 states: expose.values.map((item) => `${item}:${item}`).join(';'),
@@ -76,7 +87,7 @@ function genState(expose, role, name, desc) {
                 name: stateName,
                 icon: undefined,
                 role: role || 'state',
-                write: write,
+                write: writable,
                 read: true,
                 type: 'string',
             };
@@ -88,12 +99,62 @@ function genState(expose, role, name, desc) {
         default:
             break;
     }
+    console.log(`state = ${JSON.stringify(state)}`);
 
     return state;
 }
 
+
+
 function createFromExposes(model, def) {
     const states = [];
+    states.push = function (state, access) {
+        if (state === undefined) {
+            return this.length;
+        }
+        state.readable = (access & ea.STATE) > 0;
+        state.writable = (access & ea.SET) > 0;
+        console.log('push state = ' + JSON.stringify(state) + ' access = ' + JSON.stringify(access));
+        const stateExists = this.findIndex( (element, index, array) => (element.id === state.id ));
+        console.log('push stateExists = ' + JSON.stringify(stateExists) + ' state = ' + JSON.stringify(this[stateExists]));
+        if (stateExists < 0 ) {
+            return Array.prototype.push.call(this, state);
+        }
+        else {
+            if ( (state.readable) && (! this[stateExists].readable ) ) {
+                if (this[stateExists].hasOwnProperty('isAction')) {
+                    this[stateExists].isAction = false;
+                }
+                this[stateExists].read = state.read;
+                if (this[stateExists].role === 'button') {
+                    this[stateExists].role = state.role;
+                }
+                if ( state.hasOwnProperty('getter') ) {
+                    this[stateExists].getter = state.getter;
+                }
+                this[stateExists].prop = state.prop;
+                this[stateExists].readable = true;
+            }
+            if ( (state.writable) && (! this[stateExists].writable ) ) {
+                this[stateExists].write = state.write;
+                if ( state.hasOwnProperty('setter') ) {
+                    this[stateExists].setter = state.setter;
+                }
+                if ( state.hasOwnProperty('prop') ) {
+                    this[stateExists].prop = state.prop;
+                }
+                if ( state.hasOwnProperty('setattr') ) {
+                    this[stateExists].setattr = state.setattr;
+                }
+                if ( state.hasOwnProperty('epname') ) {
+                    this[stateExists].epname = state.epname;
+                }
+                this[stateExists].writable = true;
+            }
+            console.log('push newstate = ' + JSON.stringify(this[stateExists]));
+            return this.length;
+        }
+    }
     const icon = `https://www.zigbee2mqtt.io/images/devices/${model.replace('/','-')}.jpg`;
     for (const expose of def.exposes) {
         let state;
@@ -116,7 +177,7 @@ function createFromExposes(model, def) {
                                 setter: (value) => (value) ? prop.value_on || 'ON' : ((prop.value_off != undefined) ? prop.value_off : 'OFF'),
                                 epname: expose.endpoint,
                                 setattr: 'state',
-                            });
+                            }, prop.access);
                             break;
                         }
                         case 'brightness': {
@@ -153,8 +214,8 @@ function createFromExposes(model, def) {
                                 },
                                 epname: expose.endpoint,
                                 setattr: 'brightness',
-                            });
-                            states.push(statesDefs.brightness_move);
+                            }, prop.access);
+                            states.push(statesDefs.brightness_move, prop.access);
                             break;
                         }
                         case 'color_temp': {
@@ -179,8 +240,8 @@ function createFromExposes(model, def) {
                                     return {...options, transition: transitionTime};
                                 },
                                 epname: expose.endpoint,
-                            });
-                            states.push(statesDefs.colortemp_move);
+                            }, prop.access);
+                            states.push(statesDefs.colortemp_move, prop.access);
                             break;
                         }
                         case 'color_xy': {
@@ -235,7 +296,7 @@ function createFromExposes(model, def) {
                                 },
                                 epname: expose.endpoint,
                                 setattr: 'color',
-                            });
+                            }, prop.access);
                             break;
                         }
                         case 'color_hs': {
@@ -266,7 +327,7 @@ function createFromExposes(model, def) {
                                 },
                                 epname: expose.endpoint,
                                 setattr: 'color',
-                            });
+                            }, prop.access);
                             states.push({
                                 id: expose.endpoint ? `hue_${expose.endpoint}` : 'hue',
                                 prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
@@ -306,7 +367,7 @@ function createFromExposes(model, def) {
                                     return {...options, transition: transitionTime};
                                 },
 
-                            });
+                            }, prop.access);
                             states.push({
                                 id: expose.endpoint ? `saturation_${expose.endpoint}` : 'saturation',
                                 prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
@@ -346,9 +407,9 @@ function createFromExposes(model, def) {
                                     return {...options, transition: transitionTime};
                                 },
 
-                            });
-                            states.push(statesDefs.hue_move);
-                            states.push(statesDefs.saturation_move);
+                            }, prop.access);
+                            states.push(statesDefs.hue_move, prop.access);
+                            states.push(statesDefs.saturation_move, prop.access);
                             states.push({
                                 id: 'hue_calibration',
                                 prop: 'color',
@@ -386,25 +447,25 @@ function createFromExposes(model, def) {
                                     return {...options, transition: transitionTime};
                                 },
 
-                            });
+                            }, prop.access);
                             break;
                         }
                         default:
-                            states.push(genState(prop));
+                            states.push(genState(prop), prop.access);
                             break;
                     }
                 }
-                states.push(statesDefs.transition_time);
+                states.push(statesDefs.transition_time, ea.STATE_SET);
                 break;
 
             case 'switch':
                 for (const prop of expose.features) {
                     switch (prop.name) {
                         case 'state':
-                            states.push(genState(prop, 'switch'));
+                            states.push(genState(prop, 'switch'), prop.access);
                             break;
                         default:
-                            states.push(genState(prop));
+                            states.push(genState(prop), prop.access);
                             break;
                     }
                 }
@@ -456,7 +517,7 @@ function createFromExposes(model, def) {
                             break;
                     }
                 }
-                if (state) states.push(state);
+                if (state) states.push(state, expose.access);
                 break;
 
             case 'enum':
@@ -496,7 +557,7 @@ function createFromExposes(model, def) {
                                     isEvent: true,
                                 };
                             }
-                            states.push(state);
+                            states.push(state, expose.access);
                         }
                         state = null;
                         break;
@@ -505,7 +566,7 @@ function createFromExposes(model, def) {
                         state = genState(expose);
                         break;
                 }
-                if (state) states.push(state);
+                if (state) states.push(state, expose.access);
                 break;
 
             case 'binary':
@@ -515,7 +576,7 @@ function createFromExposes(model, def) {
                     switch (expose.name) {
                         case 'contact':
                             state = statesDefs.contact;
-                            states.push(statesDefs.opened);
+                            states.push(statesDefs.opened, ea.STATE);
                             break;
 
                         case 'battery_low':
@@ -543,12 +604,12 @@ function createFromExposes(model, def) {
                             break;
                     }
                 }
-                if (state) states.push(state);
+                if (state) states.push(state, expose.access);
                 break;
 
             case 'text':
                 state = genState(expose);
-                states.push(state);
+                states.push(state, expose.access);
                 break;
 
             case 'lock':
@@ -557,10 +618,10 @@ function createFromExposes(model, def) {
                 for (const prop of expose.features) {
                     switch (prop.name) {
                         case 'state':
-                            states.push(genState(prop, 'switch'));
+                            states.push(genState(prop, 'switch'), prop.access);
                             break;
                         default:
-                            states.push(genState(prop));
+                            states.push(genState(prop), prop.access);
                             break;
                     }
                 }
@@ -570,16 +631,16 @@ function createFromExposes(model, def) {
                 for (const prop of expose.features) {
                     switch (prop.name) {
                         case 'away_mode':
-                            states.push(statesDefs.climate_away_mode);
+                            states.push(statesDefs.climate_away_mode, prop.access);
                             break;
                         case 'system_mode':
-                            states.push(statesDefs.climate_system_mode);
+                            states.push(statesDefs.climate_system_mode, prop.access);
                             break;
                         case 'running_mode':
-                            states.push(statesDefs.climate_running_mode);
+                            states.push(statesDefs.climate_running_mode, prop.access);
                             break;
                         default:
-                            states.push(genState(prop));
+                            states.push(genState(prop), prop.access);
                             break;
                     }
                 }
@@ -588,14 +649,41 @@ function createFromExposes(model, def) {
             case 'composite':
                 for (const prop of expose.features) {
                     const st = genState(prop);
+                    st.prop = expose.property;
                     st.inOptions = true;
                     st.setterOpt = (value, options) => {
                         const result = {};
-                        result[expose.property] = {...options};
+                        options[prop.property] = value;
+                        result[expose.property] = options;
+                        console.log('setterOpt  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
                         return result;
                     };
-                    st.setattr = expose.property;
-                    states.push(st);
+                    if (prop.access & ea.SET) {
+                        st.setter = (value, options) => {
+                            const result = {};
+                            options[prop.property] = value;
+                            result[expose.property] = options;
+                            console.log('setter  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
+                            return result;
+                        };
+                        st.setattr = expose.property;
+                    };
+                    if (prop.access & ea.STATE) {
+                        st.getter = payload => {
+                            if ( (payload.hasOwnProperty(expose.property)) && (payload[expose.property]  !== null) && payload[expose.property].hasOwnProperty(prop.property)) {
+                                console.log('getter for ' +  expose.property + ' ' +  prop.property +  ' - composite - payload ' + JSON.stringify(payload) );
+                                return !isNaN(payload[expose.property][prop.property]) ? payload[expose.property][prop.property] : undefined
+                            }
+                            else {
+                                return undefined;
+                            }
+                        };
+                    }
+                    else {
+                        st.getter = payload =>{ return undefined };
+                    }
+                    ;
+                    states.push(st, prop.access);
                 }
                 break;
             default:
@@ -608,7 +696,13 @@ function createFromExposes(model, def) {
         states: states,
         exposed: true,
     };
-    //console.log(`Created mapping for device ${model}: ${safeJsonStringify(newDev, null, ' ')}`);
+    console.log(`Created mapping for device ${model}: ${JSON.stringify(newDev, function(key, value) {
+  if (typeof value === 'function') {
+    return value.toString();
+  } else {
+    return value;
+  }
+}, ' ')}`);
     return newDev;
 }
 
@@ -620,6 +714,7 @@ function applyExposes(mappedDevices, byModel, allExcludesObj) {
         const strippedModel = (deviceDef.model) ? deviceDef.model.replace(/\0.*$/g, '').trim() : '';
         // check if device is mapped
         const existsMap = byModel.get(strippedModel);
+
         if ((deviceDef.hasOwnProperty('exposes') && (!existsMap || !existsMap.hasOwnProperty('states'))) || allExcludesStr.indexOf(strippedModel) > 0) {
             const newDevice = createFromExposes(strippedModel, deviceDef);
             if (!existsMap) {

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -117,15 +117,15 @@ function createFromExposes(model, def) {
     //      .withFeature(exposes.binary('some_option', ea.SET, true, false).withDescription('Some Option'))
     //in this case one state - `some_option` has two different exposes for set an get, we have to combine it ...
     //
-    states.push = function (state, access) {
+    function pushToStates(state, access) {
         if (state === undefined) {
-            return this.length;
+            return 0;
         }
         state.readable = (access & ea.STATE) > 0;
         state.writable = (access & ea.SET) > 0;
         //console.log('push state = ' + JSON.stringify(state) + ' access = ' + JSON.stringify(access));
-        const stateExists = this.findIndex( (element, index, array) => (element.id === state.id ));
-        //console.log('push stateExists = ' + JSON.stringify(stateExists) + ' state = ' + JSON.stringify(this[stateExists]));
+        const stateExists = states.findIndex( (element, index, array) => (element.id === state.id ));
+        //console.log('push stateExists = ' + JSON.stringify(stateExists) + ' state = ' + JSON.stringify(states[stateExists]));
         if (stateExists < 0 ) {
             if (! state.writable) {
                 state.write = false;
@@ -142,81 +142,81 @@ function createFromExposes(model, def) {
                     state.getter = payload => ( undefined );
                 }
             }
-            return Array.prototype.push.call(this, state);
+            return states.push(state);
         }
         else {
-            if ( (state.readable) && (! this[stateExists].readable ) ) {
-                this[stateExists].read = state.read;
+            if ( (state.readable) && (! states[stateExists].readable ) ) {
+                states[stateExists].read = state.read;
                 // as state is readable, it can't be button or event
-                if (this[stateExists].role === 'button') {
-                    this[stateExists].role = state.role;
+                if (states[stateExists].role === 'button') {
+                    states[stateExists].role = state.role;
                 }
-                if (this[stateExists].hasOwnProperty('isEvent')) {
-                    delete this[stateExists].isEvent;
+                if (states[stateExists].hasOwnProperty('isEvent')) {
+                    delete states[stateExists].isEvent;
                 }
                 // we have to use the getter from "new" state
                 if ( state.hasOwnProperty('getter') ) {
-                    this[stateExists].getter = state.getter;
+                    states[stateExists].getter = state.getter;
                 }
                 // trying to remove the `prop` property, as main key for get and set,
                 // as it can be different in new and old states, and leave only:
                 // setattr for old and id for new
                 if (( state.hasOwnProperty('prop') ) && (state.prop === state.id)) {
-                    if ( this[stateExists].hasOwnProperty('prop') ) {
-                        if (this[stateExists].prop !== this[stateExists].id) {
-                            if (! this[stateExists].hasOwnProperty('setattr')) {
-                                this[stateExists].setattr = this[stateExists].prop;
+                    if ( states[stateExists].hasOwnProperty('prop') ) {
+                        if (states[stateExists].prop !== states[stateExists].id) {
+                            if (! states[stateExists].hasOwnProperty('setattr')) {
+                                states[stateExists].setattr = states[stateExists].prop;
                             }
                         }
-                        delete this[stateExists].prop;
+                        delete states[stateExists].prop;
                     }
                 }
                 else if ( state.hasOwnProperty('prop') ) {
-                    this[stateExists].prop = state.prop;
+                    states[stateExists].prop = state.prop;
                 }
-                this[stateExists].readable = true;
+                states[stateExists].readable = true;
             }
-            if ( (state.writable) && (! this[stateExists].writable ) ) {
-                this[stateExists].write = state.write;
+            if ( (state.writable) && (! states[stateExists].writable ) ) {
+                states[stateExists].write = state.write;
                 // use new state `setter`
                 if ( state.hasOwnProperty('setter') ) {
-                    this[stateExists].setter = state.setter;
+                    states[stateExists].setter = state.setter;
                 }
                 // use new state `setterOpt`
                 if ( state.hasOwnProperty('setterOpt') ) {
-                    this[stateExists].setterOpt = state.setterOpt;
+                    states[stateExists].setterOpt = state.setterOpt;
                 }
                 // use new state `inOptions`
                 if ( state.hasOwnProperty('inOptions') ) {
-                    this[stateExists].inOptions = state.inOptions;
+                    states[stateExists].inOptions = state.inOptions;
                 }
                 // as we have new state, responsible for set, we have to use new `isOption`
                 // or remove it
                 if (((! state.hasOwnProperty('isOption') ) || (state.isOptions === false))
-                     && (this[stateExists].hasOwnProperty('isOption'))) {
-                    delete this[stateExists].isOption;
+                     && (states[stateExists].hasOwnProperty('isOption'))) {
+                    delete states[stateExists].isOption;
                 }
                 else {
-                    this[stateExists].isOption = state.isOption;
+                    states[stateExists].isOption = state.isOption;
                 }
                 // use new `setattr` or `prop` as `setattr`
                 if ( state.hasOwnProperty('setattr') ) {
-                    this[stateExists].setattr = state.setattr;
+                    states[stateExists].setattr = state.setattr;
                 }
                 else if ( state.hasOwnProperty('prop') ) {
-                    this[stateExists].setattr = state.prop;
+                    states[stateExists].setattr = state.prop;
                 }
                 // remove `prop` equal to if, due to prop is uses as key in set and get
-                if ( this[stateExists].prop === this[stateExists].id) {
-                    delete this[stateExists].prop;
+                if ( states[stateExists].prop === states[stateExists].id) {
+                    delete states[stateExists].prop;
                 }
                 if ( state.hasOwnProperty('epname') ) {
-                    this[stateExists].epname = state.epname;
+                    states[stateExists].epname = state.epname;
                 }
-                this[stateExists].writable = true;
+                states[stateExists].writable = true;
             }
-            //console.log('push newstate = ' + JSON.stringify(this[stateExists]));
-            return this.length;
+            //console.log('push newstate = ' + JSON.stringify(states[stateExists]));
+            return states.length;
         }
     }
     const icon = `https://www.zigbee2mqtt.io/images/devices/${model.replace('/','-')}.jpg`;
@@ -229,7 +229,7 @@ function createFromExposes(model, def) {
                     switch (prop.name) {
                         case 'state': {
                             const stateNameS = expose.endpoint ? `state_${expose.endpoint}` : 'state';
-                            states.push({
+                            pushToStates({
                                 id: stateNameS,
                                 name: `Switch state ${expose.endpoint ? expose.endpoint : ''}`.trim(),
                                 icon: undefined,
@@ -246,7 +246,7 @@ function createFromExposes(model, def) {
                         }
                         case 'brightness': {
                             const stateNameB = expose.endpoint ? `brightness_${expose.endpoint}` : 'brightness';
-                            states.push({
+                            pushToStates({
                                 id: stateNameB,
                                 name: `Brightness ${expose.endpoint ? expose.endpoint : ''}`.trim(),
                                 icon: undefined,
@@ -279,12 +279,12 @@ function createFromExposes(model, def) {
                                 epname: expose.endpoint,
                                 setattr: 'brightness',
                             }, prop.access);
-                            states.push(statesDefs.brightness_move, prop.access);
+                            pushToStates(statesDefs.brightness_move, prop.access);
                             break;
                         }
                         case 'color_temp': {
                             const stateNameT = expose.endpoint ? `colortemp_${expose.endpoint}` : 'colortemp';
-                            states.push({
+                            pushToStates({
                                 id: stateNameT,
                                 prop: expose.endpoint ? `color_temp_${expose.endpoint}` : 'color_temp',
                                 name: `Color temperature ${expose.endpoint ? expose.endpoint : ''}`.trim(),
@@ -305,12 +305,12 @@ function createFromExposes(model, def) {
                                 },
                                 epname: expose.endpoint,
                             }, prop.access);
-                            states.push(statesDefs.colortemp_move, prop.access);
+                            pushToStates(statesDefs.colortemp_move, prop.access);
                             break;
                         }
                         case 'color_xy': {
                             const stateNameC = expose.endpoint ? `color_${expose.endpoint}` : 'color';
-                            states.push({
+                            pushToStates({
                                 id: stateNameC,
                                 prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
                                 name: `Color ${expose.endpoint ? expose.endpoint : ''}`.trim(),
@@ -365,7 +365,7 @@ function createFromExposes(model, def) {
                         }
                         case 'color_hs': {
                             const stateNameH = expose.endpoint ? `color_${expose.endpoint}` : 'color';
-                            states.push({
+                            pushToStates({
                                 id: stateNameH,
                                 prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
                                 name: `Color ${expose.endpoint ? expose.endpoint : ''}`.trim(),
@@ -392,7 +392,7 @@ function createFromExposes(model, def) {
                                 epname: expose.endpoint,
                                 setattr: 'color',
                             }, prop.access);
-                            states.push({
+                            pushToStates({
                                 id: expose.endpoint ? `hue_${expose.endpoint}` : 'hue',
                                 prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
                                 name: `Hue ${expose.endpoint ? expose.endpoint : ''}`.trim(),
@@ -432,7 +432,7 @@ function createFromExposes(model, def) {
                                 },
 
                             }, prop.access);
-                            states.push({
+                            pushToStates({
                                 id: expose.endpoint ? `saturation_${expose.endpoint}` : 'saturation',
                                 prop: expose.endpoint ? `color_${expose.endpoint}` : 'color',
                                 name: `Saturation ${expose.endpoint ? expose.endpoint : ''}`.trim(),
@@ -472,9 +472,9 @@ function createFromExposes(model, def) {
                                 },
 
                             }, prop.access);
-                            states.push(statesDefs.hue_move, prop.access);
-                            states.push(statesDefs.saturation_move, prop.access);
-                            states.push({
+                            pushToStates(statesDefs.hue_move, prop.access);
+                            pushToStates(statesDefs.saturation_move, prop.access);
+                            pushToStates({
                                 id: 'hue_calibration',
                                 prop: 'color',
                                 name: 'Hue color calibration table',
@@ -515,21 +515,21 @@ function createFromExposes(model, def) {
                             break;
                         }
                         default:
-                            states.push(genState(prop), prop.access);
+                            pushToStates(genState(prop), prop.access);
                             break;
                     }
                 }
-                states.push(statesDefs.transition_time, ea.STATE_SET);
+                pushToStates(statesDefs.transition_time, ea.STATE_SET);
                 break;
 
             case 'switch':
                 for (const prop of expose.features) {
                     switch (prop.name) {
                         case 'state':
-                            states.push(genState(prop, 'switch'), prop.access);
+                            pushToStates(genState(prop, 'switch'), prop.access);
                             break;
                         default:
-                            states.push(genState(prop), prop.access);
+                            pushToStates(genState(prop), prop.access);
                             break;
                     }
                 }
@@ -581,7 +581,7 @@ function createFromExposes(model, def) {
                             break;
                     }
                 }
-                if (state) states.push(state, expose.access);
+                if (state) pushToStates(state, expose.access);
                 break;
 
             case 'enum':
@@ -621,7 +621,7 @@ function createFromExposes(model, def) {
                                     isEvent: true,
                                 };
                             }
-                            states.push(state, expose.access);
+                            pushToStates(state, expose.access);
                         }
                         state = null;
                         break;
@@ -630,7 +630,7 @@ function createFromExposes(model, def) {
                         state = genState(expose);
                         break;
                 }
-                if (state) states.push(state, expose.access);
+                if (state) pushToStates(state, expose.access);
                 break;
 
             case 'binary':
@@ -640,7 +640,7 @@ function createFromExposes(model, def) {
                     switch (expose.name) {
                         case 'contact':
                             state = statesDefs.contact;
-                            states.push(statesDefs.opened, ea.STATE);
+                            pushToStates(statesDefs.opened, ea.STATE);
                             break;
 
                         case 'battery_low':
@@ -668,12 +668,12 @@ function createFromExposes(model, def) {
                             break;
                     }
                 }
-                if (state) states.push(state, expose.access);
+                if (state) pushToStates(state, expose.access);
                 break;
 
             case 'text':
                 state = genState(expose);
-                states.push(state, expose.access);
+                pushToStates(state, expose.access);
                 break;
 
             case 'lock':
@@ -682,10 +682,10 @@ function createFromExposes(model, def) {
                 for (const prop of expose.features) {
                     switch (prop.name) {
                         case 'state':
-                            states.push(genState(prop, 'switch'), prop.access);
+                            pushToStates(genState(prop, 'switch'), prop.access);
                             break;
                         default:
-                            states.push(genState(prop), prop.access);
+                            pushToStates(genState(prop), prop.access);
                             break;
                     }
                 }
@@ -695,16 +695,16 @@ function createFromExposes(model, def) {
                 for (const prop of expose.features) {
                     switch (prop.name) {
                         case 'away_mode':
-                            states.push(statesDefs.climate_away_mode, prop.access);
+                            pushToStates(statesDefs.climate_away_mode, prop.access);
                             break;
                         case 'system_mode':
-                            states.push(statesDefs.climate_system_mode, prop.access);
+                            pushToStates(statesDefs.climate_system_mode, prop.access);
                             break;
                         case 'running_mode':
-                            states.push(statesDefs.climate_running_mode, prop.access);
+                            pushToStates(statesDefs.climate_running_mode, prop.access);
                             break;
                         default:
-                            states.push(genState(prop), prop.access);
+                            pushToStates(genState(prop), prop.access);
                             break;
                     }
                 }
@@ -750,7 +750,7 @@ function createFromExposes(model, def) {
                         st.getter = payload => { return undefined };
                     }
                     ;
-                    states.push(st, prop.access);
+                    pushToStates(st, prop.access);
                 }
                 break;
             default:

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -9,9 +9,6 @@ const ea = zigbeeHerdsmanConverters.exposes.access;
 
 function genState(expose, role, name, desc) {
     let state;
-    //console.log(`expose = ${JSON.stringify(expose)} role = ${JSON.stringify(role)} name =  ${JSON.stringify(name)}  desc =  ${JSON.stringify(desc)}`);
-    // write if access.SET or access.STATE_SET or access.ALL
-    //const write = [2, 3, 7].includes(expose.access);
     const readable = (expose.access & ea.STATE) > 0;
     const writable = (expose.access & ea.SET) > 0;
     const stateId = (name || expose.property).replace(/\*/g, '');
@@ -99,7 +96,6 @@ function genState(expose, role, name, desc) {
         default:
             break;
     }
-    //console.log(`state = ${JSON.stringify(state)}`);
 
     return state;
 }
@@ -123,9 +119,7 @@ function createFromExposes(model, def) {
         }
         state.readable = (access & ea.STATE) > 0;
         state.writable = (access & ea.SET) > 0;
-        //console.log('push state = ' + JSON.stringify(state) + ' access = ' + JSON.stringify(access));
         const stateExists = states.findIndex( (element, index, array) => (element.id === state.id ));
-        //console.log('push stateExists = ' + JSON.stringify(stateExists) + ' state = ' + JSON.stringify(states[stateExists]));
         if (stateExists < 0 ) {
             if (! state.writable) {
                 state.write = false;
@@ -215,7 +209,6 @@ function createFromExposes(model, def) {
                 }
                 states[stateExists].writable = true;
             }
-            //console.log('push newstate = ' + JSON.stringify(states[stateExists]));
             return states.length;
         }
     }
@@ -720,7 +713,6 @@ function createFromExposes(model, def) {
                         const result = {};
                         options[prop.property] = value;
                         result[expose.property] = options;
-                        //console.log('setterOpt  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
                         return result;
                     };
                     // if we have a composite expose, the value have to be an object {expose.property : {prop.property: value}}
@@ -729,7 +721,6 @@ function createFromExposes(model, def) {
                             const result = {};
                             options[prop.property] = value;
                             result[expose.property] = options;
-                            //console.log('setter  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
                             return result;
                         };
                         st.setattr = expose.property;
@@ -738,7 +729,6 @@ function createFromExposes(model, def) {
                     if (prop.access & ea.STATE) {
                         st.getter = payload => {
                             if ( (payload.hasOwnProperty(expose.property)) && (payload[expose.property]  !== null) && payload[expose.property].hasOwnProperty(prop.property)) {
-                                //console.log('getter for ' +  expose.property + ' ' +  prop.property +  ' - composite - payload ' + JSON.stringify(payload) );
                                 return !isNaN(payload[expose.property][prop.property]) ? payload[expose.property][prop.property] : undefined
                             }
                             else {

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -9,7 +9,7 @@ const ea = zigbeeHerdsmanConverters.exposes.access;
 
 function genState(expose, role, name, desc) {
     let state;
-    console.log(`expose = ${JSON.stringify(expose)} role = ${JSON.stringify(role)} name =  ${JSON.stringify(name)}  desc =  ${JSON.stringify(desc)}`);
+    //console.log(`expose = ${JSON.stringify(expose)} role = ${JSON.stringify(role)} name =  ${JSON.stringify(name)}  desc =  ${JSON.stringify(desc)}`);
     // write if access.SET or access.STATE_SET or access.ALL
     //const write = [2, 3, 7].includes(expose.access);
     const readable = (expose.access & ea.STATE) > 0;
@@ -26,14 +26,14 @@ function genState(expose, role, name, desc) {
                 icon: undefined,
                 role: role || 'state',
                 write: writable,
-                read: readable,
+                read: true,
                 type: 'boolean',
             };
             if (readable) {
                 state.getter = payload => (payload[propName] === (expose.value_on || 'ON'));
             }
             else {
-                state.role = 'button';
+                state.getter = payload => ( undefined);
             }
             if (writable) {
                 state.setter = (value) => (value) ? (expose.value_on || 'ON') : ((expose.value_off != undefined) ? expose.value_off : 'OFF');
@@ -99,7 +99,7 @@ function genState(expose, role, name, desc) {
         default:
             break;
     }
-    console.log(`state = ${JSON.stringify(state)}`);
+    //console.log(`state = ${JSON.stringify(state)}`);
 
     return state;
 }
@@ -108,50 +108,114 @@ function genState(expose, role, name, desc) {
 
 function createFromExposes(model, def) {
     const states = [];
+    // make the different (set and get) part of state is updatable if different exposes is used for get and set
+    // as example:
+    //  ...
+    //  exposes.binary('some_option', ea.STATE, true, false).withDescription('Some Option'),
+    //  exposes.composite('options', 'options')
+    //      .withDescription('Some composite Options')
+    //      .withFeature(exposes.binary('some_option', ea.SET, true, false).withDescription('Some Option'))
+    //in this case one state - `some_option` has two different exposes for set an get, we have to combine it ...
+    //
     states.push = function (state, access) {
         if (state === undefined) {
             return this.length;
         }
         state.readable = (access & ea.STATE) > 0;
         state.writable = (access & ea.SET) > 0;
-        console.log('push state = ' + JSON.stringify(state) + ' access = ' + JSON.stringify(access));
+        //console.log('push state = ' + JSON.stringify(state) + ' access = ' + JSON.stringify(access));
         const stateExists = this.findIndex( (element, index, array) => (element.id === state.id ));
-        console.log('push stateExists = ' + JSON.stringify(stateExists) + ' state = ' + JSON.stringify(this[stateExists]));
+        //console.log('push stateExists = ' + JSON.stringify(stateExists) + ' state = ' + JSON.stringify(this[stateExists]));
         if (stateExists < 0 ) {
+            if (! state.writable) {
+                state.write = false;
+                if ( state.hasOwnProperty('setter') ) {
+                    delete state.setter;
+                }
+                if ( state.hasOwnProperty('setattr') ) {
+                    delete state.setattr;
+                }
+            }
+            if (! state.readable) {
+                if (state.hasOwnProperty('getter') ) {
+                    //to awid some worning on unprocessed data
+                    state.getter = payload => ( undefined );
+                }
+            }
             return Array.prototype.push.call(this, state);
         }
         else {
             if ( (state.readable) && (! this[stateExists].readable ) ) {
-                if (this[stateExists].hasOwnProperty('isAction')) {
-                    this[stateExists].isAction = false;
-                }
                 this[stateExists].read = state.read;
+                // as state is readable, it can't be button or action
                 if (this[stateExists].role === 'button') {
                     this[stateExists].role = state.role;
                 }
+                if (this[stateExists].hasOwnProperty('isAction')) {
+                    this[stateExists].isAction = false;
+                }
+                // we have to use the getter from "new" state
                 if ( state.hasOwnProperty('getter') ) {
                     this[stateExists].getter = state.getter;
                 }
-                this[stateExists].prop = state.prop;
+                // trying to remove the `prop` property, as main key for get and set,
+                // as it can be different in new and old states, and leave only:
+                // setattr for old and id for new
+                if (( state.hasOwnProperty('prop') ) && (state.prop === state.id)) {
+                    if ( this[stateExists].hasOwnProperty('prop') ) {
+                        if (this[stateExists].prop !== this[stateExists].id) {
+                            if (! this[stateExists].hasOwnProperty('setattr')) {
+                                this[stateExists].setattr = this[stateExists].prop;
+                            }
+                        }
+                        delete this[stateExists].prop;
+                    }
+                }
+                else if ( state.hasOwnProperty('prop') ) {
+                    this[stateExists].prop = state.prop;
+                }
                 this[stateExists].readable = true;
             }
             if ( (state.writable) && (! this[stateExists].writable ) ) {
                 this[stateExists].write = state.write;
+                // use new state `setter`
                 if ( state.hasOwnProperty('setter') ) {
                     this[stateExists].setter = state.setter;
                 }
-                if ( state.hasOwnProperty('prop') ) {
-                    this[stateExists].prop = state.prop;
+                // use new state `setterOpt`
+                if ( state.hasOwnProperty('setterOpt') ) {
+                    this[stateExists].setterOpt = state.setterOpt;
                 }
+                // use new state `inOptions`
+                if ( state.hasOwnProperty('inOptions') ) {
+                    this[stateExists].inOptions = state.inOptions;
+                }
+                // as we have new state, responsible for set, we have to use new `isOption`
+                // or remove it
+                if (((! state.hasOwnProperty('isOption') ) || (state.isOptions === false))
+                     && (this[stateExists].hasOwnProperty('isOption'))) {
+                    delete this[stateExists].isOption;
+                }
+                else {
+                    this[stateExists].isOption = state.isOption;
+                }
+                // use new `setattr` or `prop` as `setattr`
                 if ( state.hasOwnProperty('setattr') ) {
                     this[stateExists].setattr = state.setattr;
+                }
+                else if ( state.hasOwnProperty('prop') ) {
+                    this[stateExists].setattr = state.prop;
+                }
+                // remove `prop` equal to if, due to prop is uses as key in set and get
+                if ( this[stateExists].prop === this[stateExists].id) {
+                    delete this[stateExists].prop;
                 }
                 if ( state.hasOwnProperty('epname') ) {
                     this[stateExists].epname = state.epname;
                 }
                 this[stateExists].writable = true;
             }
-            console.log('push newstate = ' + JSON.stringify(this[stateExists]));
+            //console.log('push newstate = ' + JSON.stringify(this[stateExists]));
             return this.length;
         }
     }
@@ -651,27 +715,30 @@ function createFromExposes(model, def) {
                     const st = genState(prop);
                     st.prop = expose.property;
                     st.inOptions = true;
+                    // I'm not fully sure, as it really needed, but
                     st.setterOpt = (value, options) => {
                         const result = {};
                         options[prop.property] = value;
                         result[expose.property] = options;
-                        console.log('setterOpt  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
+                        //console.log('setterOpt  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
                         return result;
                     };
+                    // if we have a composite expose, the value have to be an object {expose.property : {prop.property: value}}
                     if (prop.access & ea.SET) {
                         st.setter = (value, options) => {
                             const result = {};
                             options[prop.property] = value;
                             result[expose.property] = options;
-                            console.log('setter  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
+                            //console.log('setter  for ' +  expose.property + ' ' +  prop.property +  '- composite - value ' + JSON.stringify(value) + ' options ' + JSON.stringify(options) + ' result ' + JSON.stringify(result) );
                             return result;
                         };
                         st.setattr = expose.property;
                     };
+                    // if we have a composite expose, the payload will be an object {expose.property : {prop.property: value}}
                     if (prop.access & ea.STATE) {
                         st.getter = payload => {
                             if ( (payload.hasOwnProperty(expose.property)) && (payload[expose.property]  !== null) && payload[expose.property].hasOwnProperty(prop.property)) {
-                                console.log('getter for ' +  expose.property + ' ' +  prop.property +  ' - composite - payload ' + JSON.stringify(payload) );
+                                //console.log('getter for ' +  expose.property + ' ' +  prop.property +  ' - composite - payload ' + JSON.stringify(payload) );
                                 return !isNaN(payload[expose.property][prop.property]) ? payload[expose.property][prop.property] : undefined
                             }
                             else {
@@ -680,7 +747,7 @@ function createFromExposes(model, def) {
                         };
                     }
                     else {
-                        st.getter = payload =>{ return undefined };
+                        st.getter = payload => { return undefined };
                     }
                     ;
                     states.push(st, prop.access);
@@ -696,13 +763,9 @@ function createFromExposes(model, def) {
         states: states,
         exposed: true,
     };
-    console.log(`Created mapping for device ${model}: ${JSON.stringify(newDev, function(key, value) {
-  if (typeof value === 'function') {
-    return value.toString();
-  } else {
-    return value;
-  }
-}, ' ')}`);
+    // make the function code printable in log
+    //console.log(`Created mapping for device ${model}: ${JSON.stringify(newDev, function(key, value) {
+    //  if (typeof value === 'function') {return value.toString() } else { return value } }, ' ')}`); 
     return newDev;
 }
 


### PR DESCRIPTION
Initial idea of this PR is was processing a composite exposes.
The first attempt was made for ZNCLDJ11LM/ZNCLDJ12LM, to make the exposes, which can be processed by 
appropriate converters `fz.xiaomi_curtain_options` and `tz.xiaomi_curtain_options`
After reading the documentation I made it like
```
exposes.composite('options', 'options')
   .withDescription('test')
   .withFeature(exposes.binary('reset_limits', ea.SET, true, false).withDescription('Reset limits'))
   .withFeature(exposes.binary('reverse_direction', ea.SET, true, false).withDescription('Reverse direction'))
   .withFeature(exposes.binary('hand_open', ea.STATE_SET, true, false).withDescription('Hand open')),
```
But it wan't generate and process appropriate objects ...
for `toZigbee` converter it have to make in `setter` the value equal to object
```
{
  'options' : {
        'reset_limits' : true,
        'reverse_direction' : true,
        'hand_open' : false,
  }
}
```
and process the similar payload from `fromZigbee`  in `getter` .
Currently it is in PR.
But, during the studying of devices in `zigbee-herdsman-converters`, I found interesting situation, when the same states/properties has a different structure for from and to Zigbee converters, for example:
```
        model: 'TS0601_cover',
        vendor: 'TuYa',
...
        fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
        toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options],
        exposes: [
            e.cover_position().setAccess('position', ea.STATE_SET),
            exposes.composite('options', 'options')
                .withFeature(exposes.numeric('motor_speed', ea.STATE_SET)
                    .withValueMin(0)
                    .withValueMax(255)
                    .withDescription('Motor speed'))],
```
It is mean - it has always  process a `motor_speed` as a part of `options`, i.e.
```
{
  'options' : {
        'motor_speed' : 10,
  }
}
```
and for the  `tz.tuya_cover_options` it works
```
    tuya_cover_options: {
        key: ['options'],
        convertSet: async (entity, key, value, meta) => {
...
            if (value.motor_speed != undefined) {
```
but in `fz.tuya_cover` it doesn't work at all ...
```
    tuya_cover: {
...
            }
            case tuya.dataPoints.coverSpeed: // Cover is reporting its current speed setting
                return {motor_speed: value};
```
no any nesting of the `motor_speed` into the `options`.

That's why this PR is more complex, and make possible to process the exposes with one id and different nesting

In case of a tyya_cover, this code can process the next exposes
```
        exposes: [
            e.cover_position().setAccess('position', ea.STATE_SET),
            exposes.numeric('motor_speed', ea.STATE)
                    .withValueMin(0)
                    .withValueMax(255)
                    .withDescription('Motor speed'),
            exposes.composite('options', 'options')
                .withFeature(exposes.numeric('motor_speed', ea.SET)
                    .withValueMin(0)
                    .withValueMax(255)
                    .withDescription('Motor speed'))],
```
I.e. - for `toZigbee` (ea.SET) it will make an nesting stricture in `setter`, but for `fromZigbee` it will process a simple `motor_state` in `getter`.
For this I modified the push function for states in createFromExposes, to make possible generate and combine states from different exposes (composite and non-composite) in one state with different `getter` and `setter`.

All other comments in the code.

Feel free to ask any questions ...