### PR TITLE
Quick Fix: Expose Access Handling

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -116,10 +116,12 @@ function createFromExposes(model, def) {
     //      .withFeature(exposes.binary('some_option', ea.SET, true, false).withDescription('Some Option'))
     //in this case one state - `some_option` has two different exposes for set an get, we have to combine it ...
     //
+
     function pushToStates(state, access) {
         if (state === undefined) {
             return 0;
         }
+        if (access === undefined) access = ea.ALL;
         state.readable = (access & ea.STATE) > 0;
         state.writable = (access & ea.SET) > 0;
         const stateExists = states.findIndex( (element, index, array) => (element.id === state.id ));
@@ -758,7 +760,7 @@ function createFromExposes(model, def) {
     };
     // make the function code printable in log
     //console.log(`Created mapping for device ${model}: ${JSON.stringify(newDev, function(key, value) {
-    //  if (typeof value === 'function') {return value.toString() } else { return value } }, ' ')}`); 
+    //  if (typeof value === 'function') {return value.toString() } else { return value } }, ' ')}`);
     return newDev;
 }
 


### PR DESCRIPTION
A change in exposes and a change in the way certain states are handled as composite exposes in the zigbee-herdsman-converters is causing color values to become read only and unable to set properly from ioBroker. This is caused by the access property of a composite expose not being initialised correctly if the composite expose leads to a single state in ioBroker.

A more generalised fix will be needed in the future to ensure that state access rights and parameters in iobroker are not overwritten unless the state was created via an expose. 

This fix merely grants full access to any state where the expose does not seem to provide any access definition.