### PR TITLE
Feature: CMD Response Support added

### DIFF
--- a/lib/developer.js
+++ b/lib/developer.js
@@ -92,7 +92,11 @@ class Developer {
         const zclData = obj.message.zclData;
         if (cmdType === 'functional') {
             cmd = zcl.Utils.getCluster(cid).getCommand(obj.message.cmd);
-        } else if (cmdType === 'foundation') {
+        }
+        else if (cmdType === 'functionalResp') {
+            cmd = zcl.Utils.getCluster(cid).getCommandResponse(obj.message.cmd); 
+        }
+        else if (cmdType === 'foundation') {
             cmd = zcl.Utils.getGlobalCommand((obj.message.cmd));
         } else {
             this.adapter.sendTo(obj.from, obj.command, {localErr: 'Invalid cmdType'}, obj.callback);
@@ -121,7 +125,7 @@ class Developer {
                 }
                 result.statusCode = 0;
                 this.adapter.sendTo(obj.from, obj.command, result, obj.callback);
-            });
+            },obj.message.zclSeqNum);
         } catch (exception) {
             // report exceptions
             // happens for example if user tries to send write command but did not provide value/type

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -686,7 +686,7 @@ class ZigbeeController extends EventEmitter {
         }
     }
 
-    async publish(deviceID, cid, cmd, zclData, cfg, ep, type, callback) {
+    async publish(deviceID, cid, cmd, zclData, cfg, ep, type, callback, zclSeqNum) {
         const entity = await this.resolveEntity(deviceID, ep);
         const device = entity.device;
         const endpoint = entity.endpoint;
@@ -727,7 +727,19 @@ class ZigbeeController extends EventEmitter {
                 result = await endpoint[cmd](cid, zclData, cfg);
             }
             if (callback) callback(undefined, result);
-        } else {
+        }
+        else if(type === 'functionalResp'){
+            if (!zclSeqNum) {
+                this.error(
+                  `Zigbee cannot publish commandResponse message to device because zclSeqNum is not known`
+                );
+                return;
+              }
+              cfg.disableDefaultResponse = false;
+              const result = await endpoint.commandResponse(cid, cmd, zclData, cfg, zclSeqNum);
+              if (callback) callback(undefined, result);
+        }
+        else {
             cfg.disableDefaultResponse = false;
             const result = await endpoint.command(cid, cmd, zclData, cfg);
             if (callback) callback(undefined, result);


### PR DESCRIPTION
added support for Command Response needed to support IAS ACE cluster security devices.
The changes should be fully backward compatible.
Changes are accessible via an extension to the sendToZigbee interface in iobroker javascripts. a new cmdType "functionalResp" has been added [funtionalfunctionaResp|foundation] in addition a new optional parameter "zclSeqNum" has been added.
See following example:
sendTo("zigbee.0", "sendToZigbee", { "id": senderId, "ep": "1", "cid": "ssIasAce", "cmd": "armRsp", "cmdType": "functionalResp", "zclSeqNum": msg_rcvd.meta.zclTransactionSequenceNumber, "zclData": {"armnotification": msg_rcvd.data.armmode} });

These changes help to support zigbee security devices according to the IAS ACE Cluster. Please see https://forum.iobroker.net/topic/49365/zigbee-response-aus-js-oder-blockly-schicken?_=1637881860647 for more details on supported devices and an iobroker example script.
Thank you for considering a merge.
Oliver