### PR TITLE
add setattr for color_temp

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -302,6 +302,7 @@ function createFromExposes(model, def) {
                                     return {...options, transition: transitionTime};
                                 },
                                 epname: expose.endpoint,
+								setattr: 'color_temp',
                             }, prop.access);
                             pushToStates(statesDefs.colortemp_move, prop.access);
                             break;


### PR DESCRIPTION
For ColorTemperature cannot be found an converter, if device has multiple endpoints. setattr was missing with name "color_temp". This small change fixes the issue.