### PR TITLE
Take min and max color temperatures from the exposes

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -291,8 +291,8 @@ function createFromExposes(model, def) {
                                 write: true,
                                 read: true,
                                 type: 'number',
-                                min: expose.value_min,
-                                max: expose.value_max,
+                                min: prop.value_min,
+                                max: prop.value_max,
                                 setter: (value) => {
                                     return utils.toMired(value);
                                 },


### PR DESCRIPTION
Relates to #1432

To resolve the issue, I needed to delete the previously created "colortemp" state that was missing min and max.

The slider on the devices tab is still broken.