### PR TITLE
Correct adapter tests - they got lost somehow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -44,6 +44,14 @@ jobs:
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
 
+    steps:
+      - uses: ioBroker/testing-action-adapter@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          os: ${{ matrix.os }}
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'
+
   # TODO: To enable automatic npm releases, create a token on npmjs.org
   # Enter this token as a GitHub secret (with name NPM_TOKEN) in the repository options
   # Then uncomment the following block:


### PR DESCRIPTION
This PR add the testing actions to standard worklow. They seem to got lost in the past.

This fault was detected due to the fact that a faulty code could pass into release 1.18.17 and lates repository.

@arteck 
Please review and merge - or adapt testing if this has been blocked by purpose.
