### PR TITLE
Added a option to disable the logging on warn level on device announcements

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -31,7 +31,7 @@ const updateCardInterval = setInterval(updateCardTimer, 6000);
 
 const savedSettings = [
     'port', 'panID', 'channel', 'disableLed', 'countDown', 'groups', 'extPanID', 'precfgkey', 'transmitPower',
-    'adapterType', 'debugHerdsman', 'disableBackup', 'disablePing', 'external', 'startWithInconsistent',
+    'adapterType', 'debugHerdsman', 'disableBackup', 'disablePing', 'external', 'startWithInconsistent', 'warnOnDeviceAnnouncement'
 ];
 
 function getDeviceByID(ID) {
@@ -798,6 +798,9 @@ function load(settings, onChange) {
     }
     if (settings.disablePing === undefined) {
         settings.disablePing = false;
+    }
+    if (settings.warnOnDeviceAnnouncement === undefined) {
+        settings.warnOnDeviceAnnouncement = true;
     }
 
     // example: select elements with id=key and class=value and insert value

--- a/admin/index.html
+++ b/admin/index.html
@@ -109,6 +109,10 @@
                         <input id="disableQueue" type="checkbox" class="value" />
                         <label class="translate" for="disableQueue">Disable Queue</label>
                     </div>
+                    <div class="input-field col s2 m2 l2">
+                        <input id="warnOnDeviceAnnouncement" type="checkbox" class="value" />
+                        <label class="translate" for="warnOnDeviceAnnouncement">Log warning on Zigbee device announcement</label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -689,6 +689,10 @@
                     <input id="debugHerdsman" type="checkbox" class="value"/>
                     <label class="translate" for="debugHerdsman">Zigbee-herdsman debug info</label>
                 </div>
+                <div class="input-field col s12 m6 l4 col-warnOnDeviceAnnouncement">
+                    <input id="warnOnDeviceAnnouncement" type="checkbox" class="value"/>
+                    <label class="translate" for="warnOnDeviceAnnouncement">Log warning on Zigbee device announcement</label>
+                </div>
                 <div class="input-field col s12 m6 l4">
                     <a id="reset-btn" class="waves-effect waves-light white-text btn-large translate">Reset...</a>
                 </div>

--- a/admin/tab_m.html
+++ b/admin/tab_m.html
@@ -605,6 +605,10 @@
                         <input id="disablePing" type="checkbox" class="value" />
                         <label class="translate" for="disablePing">Disable active availability check</label>
                     </div>
+                    <div class="input-field col s12 m6 l4 col-warnOnDeviceAnnouncement">
+                        <input id="warnOnDeviceAnnouncement" type="checkbox" class="value" />
+                        <label class="translate" for="warnOnDeviceAnnouncement">Log warning on Zigbee device announcement</label>
+                    </div>
                     <div class="input-field col s12 m6 l8 col-transmitPower">
                         <select id="transmitPower" class="value" >
                             <option value="" disabled selected class="translate">transmitPower</option>

--- a/io-package.json
+++ b/io-package.json
@@ -250,7 +250,8 @@
     "disablePing": false,
     "disableBackup": false,
     "external": "",
-    "startWithInconsistent": false
+    "startWithInconsistent": false,
+    "warnOnDeviceAnnouncement": true
   },
   "instanceObjects": [
     {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -83,6 +83,7 @@ class ZigbeeController extends EventEmitter {
             this.transmitPower = options.transmitPower;
         }
         this.disableLed = options.disableLed;
+        this.warnOnDeviceAnnouncement = options.warnOnDeviceAnnouncement;
 
         this.debug(`Using zigbee-herdsman with settings: ${JSON.stringify(herdsmanSettings)}`);
         this.herdsman = new ZigbeeHerdsman.Controller(herdsmanSettings, this.adapter.log);
@@ -579,7 +580,11 @@ class ZigbeeController extends EventEmitter {
         this.debug('handleDeviceAnnounce', message);
         const entity = await this.resolveEntity(message.device || message.ieeeAddr);
         const friendlyName = entity.name;
-        this.warn(`Device '${friendlyName}' announced itself`);
+        if (this.warnOnDeviceAnnouncement) {
+            this.warn(`Device '${friendlyName}' announced itself`);
+        } else {
+            this.info(`Device '${friendlyName}' announced itself`);
+        }
 
         try {
             if (entity && entity.mapped) {


### PR DESCRIPTION
It was quite annoying for me that already paired devices often showed up in the iobroker log with a warning "Device '0x00178801021390b1' announced itself". This happens especially with Philips Hue motion detectors with multiple warnings each day. 

![2023-08-21 13 23 34 iobroker iske space 350c1cf54f62](https://github.com/ioBroker/ioBroker.zigbee/assets/6121974/9e1796b0-6123-4bfb-8423-d42f560cce4a)

So I added a option to disable the logging on warn level on Zigbee device announcements.
