### PR TITLE
Bump zigbee-herdsman to 0.26.1

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -5,7 +5,7 @@ const statesDefs = require('./states.js').states;
 const rgb = require('./rgb.js');
 const utils = require('./utils.js');
 const colors = require('./colors.js');
-const ea = zigbeeHerdsmanConverters.exposes.access;
+const ea = require('zigbee-herdsman-converters/lib/exposes.js').access;
 
 function genState(expose, role, name, desc) {
     let state;

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -138,7 +138,7 @@ class StatesController extends EventEmitter {
         const result = {};
         // find model states for options and get it values
         const devStates = await this.getDevStates('0x' + devId, model);
-        if (devStates == null || devStates == undefined) {
+        if (devStates == null || devStates == undefined || devStates.states == null || devStates.states == undefined) {
             callback(result);
             return;
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,7 +108,7 @@ function flatten(arr) {
 
 const forceEndDevice = flatten(
     ['QBKG03LM', 'QBKG04LM', 'ZNMS13LM', 'ZNMS12LM']
-        .map(model => zigbeeHerdsmanConverters.devices.find((d) => d.model === model))
+        .map(model => zigbeeHerdsmanConverters.findByModel(model))
         .map(mappedModel => mappedModel.zigbeeModel));
 
 // Xiaomi uses 4151 and 4447 (lumi.plug) as manufacturer ID.

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -7,11 +7,11 @@ const utils = require('./utils');
 // Some EndDevices should be pinged
 // e.g. E11-G13 https://github.com/Koenkk/zigbee2mqtt/issues/775#issuecomment-453683846
 const forcedPingable = [
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === 'E11-G13'),
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === '53170161'),
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === 'V3-BTZB'),
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === 'SPZB0001'),
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === '014G2461')
+    zigbeeHerdsmanConverters.findByModel('E11-G13'),
+    zigbeeHerdsmanConverters.findByModel('53170161'),
+    zigbeeHerdsmanConverters.findByModel('V3-BTZB'),
+    zigbeeHerdsmanConverters.findByModel('SPZB0001'),
+    zigbeeHerdsmanConverters.findByModel('014G2461')
 ];
 
 // asgothian: 29.12.2020: Removed color and color_temp from readable

--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -4,10 +4,10 @@ const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
 const BaseExtension = require('./zbBaseExtension');
 
 const forcedConfigureOnEachStart = [
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === 'V3-BTZB'),
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === '014G2461'),
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === 'SPZB0001'),
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === 'ZK03840')
+    zigbeeHerdsmanConverters.findByModel('V3-BTZB'),
+    zigbeeHerdsmanConverters.findByModel('014G2461'),
+    zigbeeHerdsmanConverters.findByModel('SPZB0001'),
+    zigbeeHerdsmanConverters.findByModel('ZK03840')
 ];
 
 class DeviceConfigure extends BaseExtension {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -11,21 +11,20 @@ const DeviceConfigureExt = require('./zbDeviceConfigure');
 const DeviceEventExt = require('./zbDeviceEvent');
 const DelayedActionExt = require('./zbDelayedAction');
 const utils = require('./utils');
-
 const groupConverters = [
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_onoff_brightness,
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_color_colortemp,
+    zigbeeHerdsmanConverters.toZigbee.light_onoff_brightness,
+    zigbeeHerdsmanConverters.toZigbee.light_color_colortemp,
     zigbeeHerdsmanConvertersPhilips.tz.effect, // Support Hue effects for groups
-    zigbeeHerdsmanConverters.toZigbeeConverters.ignore_transition,
-    zigbeeHerdsmanConverters.toZigbeeConverters.cover_position_tilt,
-    zigbeeHerdsmanConverters.toZigbeeConverters.thermostat_occupied_heating_setpoint,
-    zigbeeHerdsmanConverters.toZigbeeConverters.tint_scene,
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_brightness_move,
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_brightness_step,
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_colortemp_step,
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_colortemp_move,
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_hue_saturation_move,
-    zigbeeHerdsmanConverters.toZigbeeConverters.light_hue_saturation_step
+    zigbeeHerdsmanConverters.toZigbee.ignore_transition,
+    zigbeeHerdsmanConverters.toZigbee.cover_position_tilt,
+    zigbeeHerdsmanConverters.toZigbee.thermostat_occupied_heating_setpoint,
+    zigbeeHerdsmanConverters.toZigbee.tint_scene,
+    zigbeeHerdsmanConverters.toZigbee.light_brightness_move,
+    zigbeeHerdsmanConverters.toZigbee.light_brightness_step,
+    zigbeeHerdsmanConverters.toZigbee.light_colortemp_step,
+    zigbeeHerdsmanConverters.toZigbee.light_colortemp_move,
+    zigbeeHerdsmanConverters.toZigbee.light_hue_saturation_move,
+    zigbeeHerdsmanConverters.toZigbee.light_hue_saturation_step
 
 
     /*   zigbeeHerdsmanConverters.toZigbeeConverters.light_onoff_brightness,

--- a/main.js
+++ b/main.js
@@ -607,7 +607,7 @@ class Zigbee extends utils.Adapter {
     async publishFromState(deviceId, model, stateModel, stateList, options) {
         let isGroup = false;
 
-        this.log.debug(`publishFromState : ${deviceId} ${model}`);
+        this.log.debug(`publishFromState : ${deviceId} ${model} ${safeJsonStringify(stateList)}`);
         if (model === 'group') {
             isGroup = true;
             deviceId = parseInt(deviceId);
@@ -704,7 +704,7 @@ class Zigbee extends utils.Adapter {
                 }
 
                 const epName = stateDesc.epname !== undefined ? stateDesc.epname : (stateDesc.prop || stateDesc.id);
-                const key = stateDesc.setattr || stateDesc.prop || stateDesc.id;
+                const key = stateDesc.prop || stateDesc.id || stateDesc.setattr;
                 this.log.debug(`convert ${key}, ${safeJsonStringify(preparedValue)}, ${safeJsonStringify(preparedOptions)}`);
 
                 let target;
@@ -965,7 +965,6 @@ class Zigbee extends utils.Adapter {
             disableBackup: this.config.disableBackup,
             extPanIdFix: extPanIdFix,
             startWithInconsistent: this.config.startWithInconsistent || false,
-            legacy: false,
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@iobroker/adapter-core": "^3.0.4",
     "tar": "^6.2.0",
     "typescript": "^5.2.2",
-    "zigbee-herdsman": "0.23.0",
-    "zigbee-herdsman-converters": "15.132.0"
+    "zigbee-herdsman": "0.26.1",
+    "zigbee-herdsman-converters": "16.6.0"
   },
   "description": "Zigbee devices",
   "devDependencies": {


### PR DESCRIPTION
Bump zigbee-herdsman-converters to 16.6.0
Fix compatibility with new herdsman
Change devices.find to findByModel
Change order of key evaluation in publishFromState and prioritize prop and id before setattr (Fix for tuya thermostat properties)