### PR TITLE
fixed broken configure parameter

### DIFF
--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -155,7 +155,7 @@ class DeviceConfigure extends BaseExtension {
                 if (mappedDevice.configure === undefined) return `No configure available for ${device.ieeeAddr} ${mappedDevice.model}.`;
                 this.info(`Configuring ${device.ieeeAddr} ${mappedDevice.model}`);
                 this.configuring.add(device.ieeeAddr);
-                if (typeof mappedDevice.configure === 'function') await mappedDevice.configure(device, coordinatorEndpoint, this);
+                if (typeof mappedDevice.configure === 'function') await mappedDevice.configure(device, coordinatorEndpoint, mappedDevice);
                 else {
                     const promises = [];
                     promises.push(...mappedDevice.configure);


### PR DESCRIPTION
my SOMRIG button always failed manual reconfiguration with a `Failed to configure. --> definition.endpoint is not a function` so I investigated and compared with zigbee2mqtt which didn't have that problem.
turns out there was a weird `this` instead of a `mappedDevice`.

with my fix my SOMRIG button suddenly started working and now sends button events to iobroker.

I assume this might effect a few other configuration issues with various devices, for me only SOMRIG had these issues, but then again all my other devices were paired and configured when I moved to iobroker.zigbee 2.x, so it might not have applied.
