### PR TITLE
a little optimization

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -3099,6 +3099,18 @@ const LegacyDevicesByModel = new Map();
 
 const groupStates = [states.groupstateupdate, states.groupmemberupdate, states.brightness_step].concat(lightStatesWithColor);
 
+//it's necessary once, because legacy_devices is a constant array  
+function fillLegacyDevicesByModel()
+{
+    for (const device of legacy_devices) {
+        for (const model of device.models) {
+            const stripModel = model.replace(/\0.*$/g, '').trim();
+            LegacyDevicesByModel.set(stripModel, device);
+        }
+    }
+}
+
+//fill map DevicesByModel by devices array
 function getByModel() {
     DevicesByModel.clear();
     for (const device of devices) {
@@ -3107,16 +3119,10 @@ function getByModel() {
             DevicesByModel.set(stripModel, device);
         }
     }
-    LegacyDevicesByModel.clear();
-    for (const device of legacy_devices) {
-        for (const model of device.models) {
-            const stripModel = model.replace(/\0.*$/g, '').trim();
-            LegacyDevicesByModel.set(stripModel, device);
-        }
-    }
     return DevicesByModel;
 }
 
+//Todo  what is this for?
 removeEmptyStates(devices);
 
 function fillStatesWithExposes(logger) {
@@ -3151,7 +3157,7 @@ function findModel(model, legacy) {
 }
 
 
-
+/*
 function fillDevicesForLegacy(paired) {
     devices.clear();
     for (const candidate in legacy_devices) {
@@ -3171,21 +3177,26 @@ function pairedLegacyDevices(candidates) {
         }
     }
     return rv;
-}
+}*/
 
-function setLegacyDevices(legacyModels) {
-    const legacyByModel = new Map();
-    for (const device of legacy_devices) {
-        for (const model of device.models) {
-            const stripModel = model.replace(/\0.*$/g, '').trim();
-            legacyByModel.set(stripModel, device);
-        }
-    }
+function setLegacyDevices(legacyModels, needUpdateDeviceMap) {
+    
+    if (LegacyDevicesByModel.size <1) 
+        fillLegacyDevicesByModel();
+    
+    let appended=false;
     legacyModels.forEach((model) => {
         const stripModel = model.replace(/\0.*$/g, '').trim();
-        const dev = legacyByModel.get(stripModel);
-        if (dev) devices.push(dev);
+        const dev = LegacyDevicesByModel.get(stripModel);
+        const exists = DevicesByModel.get(stripModel); 
+        if (dev && !exists){
+            devices.push(dev);
+            appended = true;
+        }
     })
+
+    if (needUpdateDeviceMap && appended)
+        getByModel();
 }
 
 function getIconforLegacyModel(model) {
@@ -3200,8 +3211,8 @@ function hasLegacyDevice(model) {
 }
 
 module.exports = {
-    devices,
-    legacy_devices,
+    //devices,
+    //legacy_devices,
     commonStates,
     commonGroupStates: [...commonStates, states.groupmemberupdate, states.groupstateupdate],
     groupStates,
@@ -3212,8 +3223,8 @@ module.exports = {
     addExposeToDevices,
     getByModel,
     findModel,
-    fillDevicesForLegacy,
-    pairedLegacyDevices,
+    //fillDevicesForLegacy,
+    //pairedLegacyDevices,
     setLegacyDevices,
     hasLegacyDevice,
     getIconforLegacyModel,

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -853,16 +853,16 @@ class StatesController extends EventEmitter {
 
     async applyLegacyDevices() {
         const legacyModels = await this.localConfig.getLegacyModels();
-        const modelarr1 = [];
-        statesMapping.devices.forEach(item => modelarr1.push(item.models));
+        //const modelarr1 = [];
+        //statesMapping.devices.forEach(item => modelarr1.push(item.models));
         statesMapping.setLegacyDevices(legacyModels);
-        const modelarr2 = [];
-        statesMapping.devices.forEach(item => modelarr2.push(item.models));
+        //const modelarr2 = [];
+        //statesMapping.devices.forEach(item => modelarr2.push(item.models));
     }
 
     async addLegacyDevice(model) {
-        statesMapping.setLegacyDevices([model]);
-        statesMapping.getByModel();
+        statesMapping.setLegacyDevices([model], true);
+        //statesMapping.getByModel();
     }
 
 
@@ -1143,29 +1143,38 @@ class StatesController extends EventEmitter {
         this.emit('debugmessage', {id: id, message:message});
     }
 
-    async publishToState(devId, model, payload, debugId) {
+    async publishToState(devId, model, payload, debugId, isCommonState) {
         try {
             if (!debugId) debugId = Date.now();
-            const devStates = await this.getDevStates(`0x${devId}`, model);
 
             const has_elevated_debug = (this.checkDebugDevice(devId) && !payload.hasOwnProperty('msg_from_zigbee'));
+            
+            if (has_elevated_debug || this.debugActive)
+            { const message = `message received '${JSON.stringify(payload)}' from device ${devId} type '${model}'`;
+              if (has_elevated_debug)    
+                     this.emit('device_debug', { ID:debugId, data: { deviceID: devId, flag:'03', IO:true }, message:message});
+               else  this.debug(message);
+            }
 
-            const message = `message received '${JSON.stringify(payload)}' from device ${devId} type '${model}'`;
-            if (has_elevated_debug)
-                this.emit('device_debug', { ID:debugId, data: { deviceID: devId, flag:'03', IO:true }, message:message});
-            else
-                if (this.debugActive) this.debug(message);
-            if (!devStates) {
-                const message = `no device states for device ${devId} type '${model}'`;
-                if (has_elevated_debug)this.emit('device_debug', { ID:debugId, data: { error:'NOSTATE',states:[{ id:'--', value:'--', payload:payload}], IO:true }, message:message});
-                else if (this.debugActive) this.debug(message);
-                return;
+            let devStates = undefined;
+            if (!isCommonState)
+            {
+                devStates = await this.getDevStates(`0x${devId}`, model);
+                if (!devStates) {
+                    const message = `no device states for device ${devId} type '${model}'`;
+                    if (has_elevated_debug)this.emit('device_debug', { ID:debugId, data: { error:'NOSTATE',states:[{ id:'--', value:'--', payload:payload}], IO:true }, message:message});
+                    else if (this.debugActive) this.debug(message);
+                    return;
+                }
             }
             // find states for payload
             let has_published = false;
-            if (devStates.states !== undefined) {
+            if ((devStates && devStates.states !== undefined) || isCommonState) {
                 try {
-                    const states = statesMapping.commonStates.concat(
+                    let states = undefined;
+                    if (isCommonState)
+                         states = statesMapping.commonStates;
+                    else states = statesMapping.commonStates.concat(
                         devStates.states.filter(statedesc => payload.hasOwnProperty(statedesc.prop || statedesc.id))
                     );
 
@@ -1184,10 +1193,12 @@ class StatesController extends EventEmitter {
                         }
 
                         let stateID = statedesc.id;
-                        const message = `value generated '${JSON.stringify(value)}' from device ${devId} for '${statedesc.name}'`;
-                        if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data: { states:[{id:stateID, value:value, payload:payload }],flag:'04', IO:true }, message});
-                        else if (this.debugActive) this.debug(message);
-
+                        if (has_elevated_debug || this.debugActive) 
+                        { const message = `value generated '${JSON.stringify(value)}' from device ${devId} for '${statedesc.name}'`;
+                          if (has_elevated_debug)
+                                 this.emit('device_debug', { ID:debugId, data: { states:[{id:stateID, value:value, payload:payload }],flag:'04', IO:true }, message});
+                            else this.debug(message);
+                        }
 
                         const common = {
                             name: statedesc.name,
@@ -1359,8 +1370,9 @@ class StatesController extends EventEmitter {
         msgForState['endpoint_id'] = message.endpoint.ID;
 
         if (has_elevated_debug) {
-            const message = `Zigbee Event of Type ${type} from device ${device.ieeeAddr}, incoming event: ${safeJsonStringify(msgForState)}`;
-            this.emit('device_debug', { ID:debugId, data: { ID: device.ieeeAddr, payload:safeJsonStringify(msgForState), flag:'01', IO:true }, message:message});
+            const msgForStateString = safeJsonStringify(msgForState);
+            const message = `Zigbee Event of Type ${type} from device ${device.ieeeAddr}, incoming event: ${msgForStateString}`;
+            this.emit('device_debug', { ID:debugId, data: { ID: device.ieeeAddr, payload:msgForStateString, flag:'01', IO:true }, message:message});
 
         }
         // this assigment give possibility to use iobroker logger in code of the converters, via meta.logger
@@ -1407,7 +1419,7 @@ class StatesController extends EventEmitter {
 
         // always publish link_quality and battery
         if (message.linkquality) { // send battery with
-            this.publishToState(devId, model, {linkquality: message.linkquality}, debugId);
+            this.publishToState(devId, model, {linkquality: message.linkquality}, debugId, true);
             if (isBattKey) {
                 this.publishToState(devId, model, {voltage: _voltage}, debugId);
                 const  battProz = zigbeeHerdsmanConvertersUtils.batteryVoltageToPercentage(_voltage,entity.mapped.meta.battery.voltageToPercentage);
@@ -1419,7 +1431,7 @@ class StatesController extends EventEmitter {
             }
         }
 
-        this.publishToState(devId, model, {msg_from_zigbee: safeJsonStringify(msgForState)}, -1);
+        this.publishToState(devId, model, {msg_from_zigbee: safeJsonStringify(msgForState)}, -1, true);
 
         if (!entity.mapped) {
             return;


### PR DESCRIPTION
**Device.js**
1. LegacyDevicesByModel  map is filled in once, because "legacy_devices" is const array
2. unused code commented out
3. When filling the list of "devices", a repeat check is performed (similar to filling through exposes)

**StatesController**
1. а little log optimization (to reduce the call to JSON.stringify )
2. The parameter "isCommonState" has been added to the method **publishToState**,  to avoid calling **getDevStates** during an update "linkquality", "msg_from_zigbee" states,  which are performed very frequently (especially relevant for PTVO firmware with a large number of channels)
