### PR TITLE
Workaround: Fixing crashes when deviceModel is empty

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -415,18 +415,21 @@ class Commands {
         }
         else {
             models.byUID[UID] = {
-                model:device.info.mapped,
+                model: device.info?.mapped || {model: device.info?.device?.modelZigbee || device.common?.type || 'unknown', type: device.info?.device?.type || 'Group', options: []},
                 availableOptions : [...device.info?.mapped?.options || [], ...['use_legacy_model']],
                 setOptions: this.adapter.stController.localConfig.getByModel(device.info?.mapped?.model || 'unknown') || [],
                 devices: [device],
             };
+            if (!models.byUID[UID].model || typeof models.byUID[UID].model !== 'object') {
+                models.byUID[UID].model = {model: device.info?.device?.modelZigbee || device.common?.type || 'unknown', type: device.info?.device?.type || 'Group', options: []};
+            }
             if (!models.byUID[UID].model.type)
-                models.byUID[UID].model.type = 'Group';
+                models.byUID[UID].model.type = device.info?.device?.type || 'Group';
             models.UIDbyModel[device.info?.mapped?.model || 'unknown'] = UID;
         }
         // check configuration
         try {
-            if (device.info) {
+            if (device.info?.device && device.info?.mapped) {
                 const result = await this.zbController.callExtensionMethod(
                     'shouldConfigure',
                     [device.info.device, device.info.mapped],
@@ -505,7 +508,7 @@ class Commands {
             if (entity.mapped) {
                 rv.mapped = {
                     model:entity.mapped.model,
-                    readKeys: entity.mapped.exposes?.find((e) => e.type == 'light') != undefined,
+                    readKeys: Array.isArray(entity.mapped?.exposes) && entity.mapped.exposes.find((e) => e.type == 'light') != undefined,
                     type:entity.device.type,
                     description:entity.mapped.description,
                     hasLegacyDef:modelDefinitions.hasLegacyDevice(entity.mapped.model),
@@ -595,20 +598,11 @@ class Commands {
                 PromiseChain.push(this.handleGroupforInfo(deviceObject, groups));
             }
             else {
-                const modelDesc = await modelDefinitions.findModel(
-                    deviceObject.common.type,
-                    entity?.device?.ieeeAddr,
-                    entity?.mapped?.legacy,
-                );
+                const modelDesc = await modelDefinitions.findModel(deviceObject.common.type, entity?.device, deviceObject.common.UUID, entity?.mapped?.legacy);
                 deviceObject.icon = (modelDesc?.icon) ? modelDesc.icon : 'img/unknown.png';
                 if (modelDesc?.vendor) deviceObject.vendor = modelDesc.vendor;
-                const arr = Array.isArray(modelDesc?.states)
-                    ? modelDesc.states.filter((s) => Array.isArray(s.readKeys)).map((s) => s.readKeys).flat()
-                    : [];
+                const arr = modelDesc.states.filter((s) => Array.isArray(s.readKeys)).map((s)=> s.readKeys).flat();
                 if (arr.length > 0) deviceObject.readKeys = arr;
-                if (!modelDesc || !Array.isArray(modelDesc.states)) {
-                    this.warn(`No valid model definition found for ${deviceObject._id} (${deviceObject.common?.type || 'unknown'} / ${entity?.device?.ieeeAddr || 'no ieee'})`);
-                }
                 deviceObject.legacyIcon = modelDefinitions.getIconforLegacyModel(deviceObject.common.type);
                 const lq_state = all_states[`${deviceObject._id}.link_quality`];
                 deviceObject.link_quality = lq_state ? lq_state.val : -1;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -598,10 +598,19 @@ class Commands {
                 PromiseChain.push(this.handleGroupforInfo(deviceObject, groups));
             }
             else {
-                const modelDesc = await modelDefinitions.findModel(deviceObject.common.type, entity?.device, deviceObject.common.UUID, entity?.mapped?.legacy);
+                const modelDesc = await modelDefinitions.findModel(
+                    deviceObject.common.type,
+                    entity?.device?.ieeeAddr,
+                    entity?.mapped?.legacy,
+                );
+                if (!modelDesc || !Array.isArray(modelDesc.states)) {
+                    this.adapter.log.warn(`No valid model definition found for ${deviceObject.common.type || 'unknown'} (${entity?.device?.ieeeAddr || id}) while building device list`);
+                }
                 deviceObject.icon = (modelDesc?.icon) ? modelDesc.icon : 'img/unknown.png';
                 if (modelDesc?.vendor) deviceObject.vendor = modelDesc.vendor;
-                const arr = modelDesc.states.filter((s) => Array.isArray(s.readKeys)).map((s)=> s.readKeys).flat();
+                const arr = Array.isArray(modelDesc?.states)
+                    ? modelDesc.states.filter((s) => Array.isArray(s.readKeys)).map((s)=> s.readKeys).flat()
+                    : [];
                 if (arr.length > 0) deviceObject.readKeys = arr;
                 deviceObject.legacyIcon = modelDefinitions.getIconforLegacyModel(deviceObject.common.type);
                 const lq_state = all_states[`${deviceObject._id}.link_quality`];

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -595,11 +595,20 @@ class Commands {
                 PromiseChain.push(this.handleGroupforInfo(deviceObject, groups));
             }
             else {
-                const modelDesc = await modelDefinitions.findModel(deviceObject.common.type, entity?.device, deviceObject.common.UUID, entity?.mapped?.legacy);
+                const modelDesc = await modelDefinitions.findModel(
+                    deviceObject.common.type,
+                    entity?.device?.ieeeAddr,
+                    entity?.mapped?.legacy,
+                );
                 deviceObject.icon = (modelDesc?.icon) ? modelDesc.icon : 'img/unknown.png';
                 if (modelDesc?.vendor) deviceObject.vendor = modelDesc.vendor;
-                const arr = modelDesc.states.filter((s) => Array.isArray(s.readKeys)).map((s)=> s.readKeys).flat();
+                const arr = Array.isArray(modelDesc?.states)
+                    ? modelDesc.states.filter((s) => Array.isArray(s.readKeys)).map((s) => s.readKeys).flat()
+                    : [];
                 if (arr.length > 0) deviceObject.readKeys = arr;
+                if (!modelDesc || !Array.isArray(modelDesc.states)) {
+                    this.warn(`No valid model definition found for ${deviceObject._id} (${deviceObject.common?.type || 'unknown'} / ${entity?.device?.ieeeAddr || 'no ieee'})`);
+                }
                 deviceObject.legacyIcon = modelDefinitions.getIconforLegacyModel(deviceObject.common.type);
                 const lq_state = all_states[`${deviceObject._id}.link_quality`];
                 deviceObject.link_quality = lq_state ? lq_state.val : -1;

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -107,7 +107,7 @@ class StatesController extends EventEmitter {
             const devId = utils.zbIdorIeeetoAdId(this, ieeeAddr, false);
             if (!this.delayedDeleteQueue)
                 this.delayedDeleteQueue = { };
-            const deviceDelayObj = this.delayedDeleteQueue ? this.delayedDeleteQueue[devId] : { };
+            const deviceDelayObj = (this.delayedDeleteQueue && this.delayedDeleteQueue[devId]) ? this.delayedDeleteQueue[devId] : { };
             if (deviceDelayObj.handle) {
                 clearTimeout(deviceDelayObj.handle);
                 this.info(`Delayed delete for device ${devId} aborted.`);

--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -64,10 +64,10 @@ class DeviceConfigure extends BaseExtension {
     }
 
     shouldConfigure(device, mappedDevice) {
-        const definitionVersion = mappedDevice.version || '0.0.0';
         if (!device || !mappedDevice) {
             return false;
         }
+        const definitionVersion = mappedDevice.version || '0.0.0';
         if (!mappedDevice || !mappedDevice.configure) {
             return false;
         }


### PR DESCRIPTION
When deviceModel is empty, the adapter is crashing when loading device list.
So i made a workaround instead of fixing the root.

Found the cause with IKEA KAJPLATS_CT. It does not show a deviceModel. 
<img width="542" height="673" alt="grafik" src="https://github.com/user-attachments/assets/c514891c-e080-435a-9d96-0a0295aba4d5" />
