### PR TITLE
Fix: send_payload device commands silently ignored

### DIFF
--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -611,7 +611,7 @@ class StatesController extends EventEmitter {
         // send_payload can never be a linked state !;
         if (stateDesc.id === 'send_payload') {
             if (zbDeviceCommands.includes(value.toLowerCase())) {
-                this.emit('zb_devicecommand', value.toLowerCase, deviceId, stateDesc);
+                this.emit('zb_devicecommand', value.toLowerCase(), deviceId, stateDesc);
             } else {
                 try {
                     const json_value = JSON.parse(value);


### PR DESCRIPTION
## Problem
Writing a device command (`configure`, `interview`, `ota`, …) to the `send_payload` state does nothing and reports no error.

## Cause
The command is emitted as `value.toLowerCase` (the function reference) instead of `value.toLowerCase()` (the lowercased string). The receiving `zbDeviceCommand()` therefore never matches a known command, so the command is silently dropped. The line directly above already calls `value.toLowerCase()` correctly in the `includes()` check:

```js
if (zbDeviceCommands.includes(value.toLowerCase())) {            // correct
    this.emit('zb_devicecommand', value.toLowerCase, deviceId, stateDesc);  // missing ()
```

## Fix
Add the missing parentheses so the lowercased command string is passed to the handler.

## Testing
Static analysis and code trace; one-character change, `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
