### PR TITLE
Fix: numeric min/max aggregation for groups

### DIFF
--- a/lib/groups.js
+++ b/lib/groups.js
@@ -95,10 +95,10 @@ class Groups {
     }
 
     setMaxVal(target, values) {
-        this.adapter.setState(target,values.sort()[values.length-1], true);
+        this.adapter.setState(target,values.sort((a, b) => a - b)[values.length-1], true);
     }
     setMinVal(target, values) {
-        this.adapter.setState(target,  values.sort()[0], true);
+        this.adapter.setState(target,  values.sort((a, b) => a - b)[0], true);
     }
 
     setAvgVal(target, values) {


### PR DESCRIPTION
## Problem
For groups using `min`/`max` state aggregation, the resulting value can be wrong for numeric members — e.g. members `[2, 10, 100]` yield max `2` and min `10`.

## Cause
`setMaxVal`/`setMinVal` call `Array.prototype.sort()` without a comparator, which sorts elements as strings (lexicographically). Lexicographically `"100" < "2"`, so the picked min/max element is incorrect.

## Fix
Use a numeric comparator `sort((a, b) => a - b)`. Returning the actual element (rather than `Math.max`/`Math.min`) preserves the original value and type, consistent with the sibling `setAvgVal`. The `values.length < 2` guard above keeps the array non-trivial.

## Testing
Static analysis and code trace; `node --check` clean. Example: `[2, 10, 100]` now yields max `100` / min `2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
