### PR TITLE
Fix: TypeError from non-existent this.log in EventEmitter-based classes

### DIFF
--- a/lib/localConfig.js
+++ b/lib/localConfig.js
@@ -292,11 +292,11 @@ class localConfig extends EventEmitter {
         if (fs.existsSync(src)  && !fs.existsSync(dst))
         {
             try {
-                this.log.info(`copying image from :${src} to ${dst}`)
+                this.adapter.log.info(`copying image from :${src} to ${dst}`)
                 fs.copyFileSync(src, dst)
             }
             catch {
-                this.log.debug(`failed to copy from :${src} to ${dst}`)
+                this.adapter.log.debug(`failed to copy from :${src} to ${dst}`)
             }
         }
     }

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1801,7 +1801,7 @@ class ZigbeeController extends EventEmitter {
             try {
                 payloadObj = JSON.parse(payload);
             } catch (e) {
-                this.log.error(`Unable to parse ${safeJsonStringify(payload)}: ${safeJsonStringify(e)}`);
+                this.error(`Unable to parse ${safeJsonStringify(payload)}: ${safeJsonStringify(e)}`);
                 return {
                     success: false,
                     error: `Unable to parse ${safeJsonStringify(payload)}: ${safeJsonStringify(e)}`
@@ -1820,16 +1820,16 @@ class ZigbeeController extends EventEmitter {
 
                 const entity = await this.resolveEntity(devID);
                 if (!entity) {
-                    this.log.error(`Device ${safeJsonStringify(payloadObj.device)} not found`);
+                    this.error(`Device ${safeJsonStringify(payloadObj.device)} not found`);
                     return {success: false, error: `Device ${safeJsonStringify(payloadObj.device)} not found`};
                 }
                 const mappedModel = entity.mapped;
                 if (!mappedModel) {
-                    this.log.error(`No Model for Device ${safeJsonStringify(payloadObj.device)}`);
+                    this.error(`No Model for Device ${safeJsonStringify(payloadObj.device)}`);
                     return {success: false, error: `No Model for Device ${safeJsonStringify(payloadObj.device)}`};
                 }
                 if (typeof payloadObj.payload !== 'object') {
-                    this.log.error(`Illegal payload type for ${safeJsonStringify(payloadObj.device)}`);
+                    this.error(`Illegal payload type for ${safeJsonStringify(payloadObj.device)}`);
                     return {success: false, error: `Illegal payload type for ${safeJsonStringify(payloadObj.device)}`};
                 }
                 const endpoints = mappedModel && mappedModel.endpoint ? mappedModel.endpoint(entity.device) : null;
@@ -1864,7 +1864,7 @@ class ZigbeeController extends EventEmitter {
                     }
                     return {success: true};
                 } catch (error) {
-                    this.log.error(`Error ${error.code} on send command to ${payload.device}.` + ` Error: ${error.stack} ` + `Send command to ${payload.device} failed with ` + error);
+                    this.error(`Error ${error.code} on send command to ${payload.device}.` + ` Error: ${error.stack} ` + `Send command to ${payload.device} failed with ` + error);
                     this.adapter.filterError(`Error ${error.code} on send command to ${payload.device}.` + ` Error: ${error.stack}`, `Send command to ${payload.device} failed with`, error);
                     return {success: false, error};
                 }


### PR DESCRIPTION
## Problem
On some error paths the adapter throws a secondary `TypeError` instead of logging the actual problem.

## Cause
`ZigbeeController` and `localConfig` extend `EventEmitter`, which has no `this.log`. Several calls use `this.log.<level>(...)`, so `this.log` is `undefined` and the call throws:
- `ZigbeeController.publishPayload` (parse / device-not-found / no-model / illegal-payload) and the send-command error path — `this.log.error`
- `localConfig.copyDeviceImage` — `this.log.info` / `this.log.debug`

## Fix
- `ZigbeeController`: use the class's own `this.error(...)`, which emits the `log` event `main.js` already listens on (consistent with the rest of the class).
- `localConfig`: use `this.adapter.log`.

## Behaviour note
These calls previously threw, so the corresponding conditions were never actually logged. After the fix they are logged at their intended levels, and a latent unhandled-rejection path on the `publishPayload` error branch is removed.

## Testing
Static analysis and code trace; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
