### PR TITLE
Fix: reconnect timer survives adapter unload (native setTimeout)

### DIFF
--- a/main.js
+++ b/main.js
@@ -530,7 +530,7 @@ class Zigbee extends adapterCore.Adapter {
     }
 
     async tryToReconnect() {
-        this.reconnectTimer = setTimeout(async () => {
+        this.reconnectTimer = this.setTimeout(async () => {
             try {
                 const result = await this.testConnection(this.config.port)
                 if (result.error) {
@@ -616,7 +616,7 @@ class Zigbee extends adapterCore.Adapter {
     }
 
     async onZigbeeAdapterReady() {
-        this.reconnectTimer && clearTimeout(this.reconnectTimer);
+        this.reconnectTimer && this.clearTimeout(this.reconnectTimer);
         this.log.info(`Zigbee started`);
         // https://github.com/ioBroker/ioBroker.zigbee/issues/668
         const extPanIdFix = this.config.extPanIdFix ? this.config.extPanIdFix : false;


### PR DESCRIPTION
## Problem
If the adapter is stopped or restarted while a reconnect attempt is pending, a timer fires on the already torn-down adapter and runs the connect path again — state writes and a herdsman re-init after unload, with a possible serial-port conflict against the freshly started instance.

## Cause
`tryToReconnect` schedules the retry with the native `setTimeout` instead of `this.setTimeout`, and `onUnload` does not clear `this.reconnectTimer`. Native timers are not tracked by adapter-core, so they survive unload. The same timer is also referenced in inconsistent styles (`this.clearTimeout` in `testConnect`, native `clearTimeout` in `onZigbeeAdapterReady`).

## Fix
- Schedule the retry with `this.setTimeout`, which adapter-core tracks and clears automatically on unload.
- Switch the matching `clearTimeout` in `onZigbeeAdapterReady` to `this.clearTimeout` for consistency (`testConnect` already uses `this.clearTimeout`).

## Testing
Static analysis and code trace; `node --check` clean.

---

Glad to help out where I can, and thanks for the work you put into this adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)