### PR TITLE
Fix: device deletion always reported as an error

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -778,8 +778,8 @@ class Commands {
             if (!dev) {
 
                 this.info(`Attempted to delete device ${devId} - the device is not known to the zigbee controller.`);
-                const err = await this.stController.deleteObj(devId);
-                if (err != '') this.adapter.sendTo(from, command, {error:err}, callback);
+                const result = await this.stController.deleteObj(devId);
+                if (!result.status) this.adapter.sendTo(from, command, {error: result.message}, callback);
                 else this.adapter.sendTo(from, command, {}, callback);
                 return;
             }
@@ -810,9 +810,9 @@ class Commands {
                 if (!err) {
                     this.info('Device removed from the network, deleting objects.')
                     if (!force) {
-                        const err = await this.stController.deleteObj(devId);
-                        if (err == '') this.adapter.sendTo(from, command, {}, callback);
-                        else this.adapter.sendTo(from, command, {error:err}, callback);
+                        const result = await this.stController.deleteObj(devId);
+                        if (result.status) this.adapter.sendTo(from, command, {}, callback);
+                        else this.adapter.sendTo(from, command, {error: result.message}, callback);
                     }
                     this.adapter.sendTo(from, command, {}, callback);
                     if (msg.dev) this.adapter.stController.localConfig.removeLocalData(devId, msg.model);
@@ -821,8 +821,8 @@ class Commands {
                 }
             });
             if (force) {
-                const err = await this.stController.deleteObj(devId);
-                if (err != '') this.adapter.sendTo(from, command, {errror:err}, callback);
+                const result = await this.stController.deleteObj(devId);
+                if (!result.status) this.adapter.sendTo(from, command, {error: result.message}, callback);
                 else this.adapter.sendTo(from, command, {}, callback);
             }
         } else {


### PR DESCRIPTION
## Problem
Deleting a device always shows an error in the admin UI, even when the device and its objects were removed successfully.

## Cause
`deleteZigbeeDevice` treats the value returned by `StatesController.deleteObj` as a string and compares it to `''`. But `deleteObj` returns an object — `{status: true}` on success or `{status: false, message: ...}` on failure. `object != ''` is always true (and `object == ''` always false), so the success path is never taken and the UI receives `{error: <result object>}` on every delete. The force branch additionally uses a misspelled key `errror`.

## Fix
Check `result.status` and send `result.message` on failure — the same pattern already used in the commented-out reference block a few lines above (`if (!result.status) ...`). Applied to all three call sites (unknown-device, graceful-remove, force-remove) and fixes the `errror` typo.

## Testing
Static analysis and code trace; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)