### PR TITLE
Fix: device stop event never fired on shutdown

### DIFF
--- a/lib/zbDeviceEvent.js
+++ b/lib/zbDeviceEvent.js
@@ -27,10 +27,8 @@ class DeviceEvent extends BaseExtension {
     }
 
     async stop() {
-        if (this.zigbee.getClients() > 0) {
-            for (const device of await this.zigbee.getClients()) {
-                await this.callOnEvent(device, 'stop', {ieeeAddr:device.ieeeAddr});
-            }
+        for (const device of await this.zigbee.getClientIterator()) {
+            await this.callOnEvent(device, 'stop', {ieeeAddr:device.ieeeAddr});
         }
     }
 


### PR DESCRIPTION
## Problem
The per-device `onEvent('stop')` cleanup (the zigbee-herdsman-converters lifecycle hook) is never executed when the adapter shuts down.

## Cause
`DeviceEvent.stop()` guards the loop with `if (this.zigbee.getClients() > 0)`. `getClients()` is `async` and returns a Promise, so `Promise > 0` evaluates to `NaN > 0` — always `false`. The loop body never runs.

## Fix
Iterate `this.zigbee.getClientIterator()` directly, mirroring `onZigbeeStarted()` which uses the same call for the `'start'` event. `getClientIterator()` returns a plain generator and works across all supported Node versions; the previous `getClients()` path relies on calling `Array.prototype.filter` on an iterator (an ES2024 Iterator Helper, available on Node >= 22 only).

## Testing
Static analysis and code trace; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)