### PR TITLE
Fix: forced reconfigure-on-start never triggers

### DIFF
--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -87,7 +87,7 @@ class DeviceConfigure extends BaseExtension {
 
             for (const device of await this.zigbee.getClients()) {
                 const mappedDevice = await zigbeeHerdsmanConverters.findByDevice(device);
-                if (forcedConfigureOnEachStart.find((d) => d && d.hasOwnProperty('zigbeeModel') && d.zigbeeModel.includes(device.modelID))) {
+                if (forcedConfigureOnEachStart.includes(device.modelID)) {
                     this.debug(`DeviceConfigure ${device.ieeeAddr} ${mappedDevice ? mappedDevice.model : device.modelID} forced by adapter config`);
                     device.meta.configured = -1; // Force a reconfiguration for this device
                 }


### PR DESCRIPTION
## Problem
The `forcedConfigureOnEachStart` list (models that should be reconfigured on every adapter start) has no effect — the listed models are never force-reconfigured.

## Cause
`forcedConfigureOnEachStart` is an array of model-ID strings (`['V3-BTZB', '014G2461', 'SPZB0001', 'ZK03840']`), but `onZigbeeStarted()` tests each entry as if it were an object: `forcedConfigureOnEachStart.find(d => d.hasOwnProperty('zigbeeModel') && d.zigbeeModel.includes(device.modelID))`. For a string entry, `hasOwnProperty('zigbeeModel')` is always false, so `find` never matches.

## Fix
Use `forcedConfigureOnEachStart.includes(device.modelID)` — straight membership against the model ID, the same pattern `lib/utils.js` already uses for its `forceEndDevice` model list.

## Testing
Static analysis and code trace; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)