### PR TITLE
Fix: updateGroupMembership falls through after missing device id

### DIFF
--- a/lib/groups.js
+++ b/lib/groups.js
@@ -364,6 +364,7 @@ class Groups {
             this.debug('updateGroupMembership called with ' + JSON.stringify(devId));
             if (devId === undefined) {
                 this.adapter.sendTo(from, command, {error: 'No device specified'}, callback);
+                return;
             }
             const sysid = devId.replace(this.adapter.namespace + '.', '0x');
             const errors = [];


### PR DESCRIPTION
## Problem
Calling `updateGroupMembership` without a device id sends the intended "No device specified" error, but also logs a spurious caught exception on every such call.

## Cause
After sending the error for `devId === undefined`, the function does not `return`. Execution falls through to `devId.replace(this.adapter.namespace + '.', '0x')` on the undefined `devId`, throwing a `TypeError`. The function's own `try/catch` swallows it (logged as "caught error … in updateGroupMembership"), so it is not a crash, but the error path is handled twice.

## Fix
`return` after sending the "No device specified" response.

## Testing
Static analysis and code trace; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)