### PR TITLE
Bugfixes and renames

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -784,47 +784,19 @@ class Commands {
                 return;
             }
             this.info(`${force ? 'Force removing' : 'Gracefully removing '} device ${devId} from the network.`);
-            /*
 
-            // if with force, remove device and object in parallel;
-            const PromiseArr = [ this.zbController.remove(sysid, force) ]
-            if (force) PromiseArr.push( this.stController.deleteObj(devId));
-
-            const results = await Promise.all(PromiseArr);
-            const msgs = [];
-            for (const result of results) {
-                if (!result.status) msgs.push(result.message ? result.message : 'failed without message');
-            }
-            if (msgs.length == 0 && !force) {
-                const result = await this.stController.deleteObj(devId);
-                if (!result.status) msgs.push(result.message ? result.message : 'failed without message');
-            }
-
-            const removeResult = this.zbController.remove(sysid, force);
-            if (removeResult.status || force) {
-                this.info('Device removed from the network, deleting objects.')
-
-            }
-            */
-            this.zbController.remove(sysid, force, async (err) => {
-                if (!err) {
-                    this.info('Device removed from the network, deleting objects.')
-                    if (!force) {
-                        const err = await this.stController.deleteObj(devId);
-                        if (err == '') this.adapter.sendTo(from, command, {}, callback);
-                        else this.adapter.sendTo(from, command, {error:err}, callback);
-                    }
-                    this.adapter.sendTo(from, command, {}, callback);
-                    if (msg.dev) this.adapter.stController.localConfig.removeLocalData(devId, msg.model);
-                } else {
-                    this.adapter.sendTo(from, command, {error: err}, callback);
+            const result = {};
+            const devDelete = await this.zbController.remove(sysid, force);
+            if (devDelete.status || force) {
+                const objDelete = await this.stController.deleteObj(devId);
+                if (!objDelete.status) {
+                    result.error = objDelete.message;
                 }
-            });
-            if (force) {
-                const err = await this.stController.deleteObj(devId);
-                if (err != '') this.adapter.sendTo(from, command, {errror:err}, callback);
-                else this.adapter.sendTo(from, command, {}, callback);
             }
+            else {
+                result.error = devDelete.error;
+            }
+            this.adapter.sendTo(from, command, result, callback);
         } else {
             this.adapter.sendTo(from, command, {error: 'No active connection to Zigbee Hardware!'}, callback);
         }

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -359,11 +359,12 @@ class Groups {
 
     async updateGroupMembership(from, command, message, callback) {
         try {
-            const groups = message && message.groups ? message.groups : {};
-            const devId = message && message.id ? message.id : undefined;
+            const groups = message?.groups ??  {};
+            const devId = message?.id ?? 'NODEVICE';
             this.debug('updateGroupMembership called with ' + JSON.stringify(devId));
-            if (devId === undefined) {
+            if (devId === 'NODEVICE') {
                 this.adapter.sendTo(from, command, {error: 'No device specified'}, callback);
+                return;
             }
             const sysid = devId.replace(this.adapter.namespace + '.', '0x');
             const errors = [];

--- a/lib/ota.js
+++ b/lib/ota.js
@@ -67,17 +67,28 @@ class Ota {
                 if (state.val) {
                     const devices = await this.adapter.getDevicesAsync();
                     const targets = devices.map((d) => d.native.id).filter((id) => id.length ==16);
-                    await this.multiCheckOtaAvail(targets);
+                    if (targets.length > 0) {
+                        // acknowledge the state
+                        await this.adapter.setStateAsync(`${this.adapter.namespace}.info.ota`, true, true);
+                        await this.multiCheckOtaAvail(targets);
+                    }
                 }
                 break;
             case 'ota_available':
                 try {
                     const arr = JSON.parse(state.val);
-                    for (const devId of arr) {
-                        const device = await this.zbController.resolveEntity(devId);
-                        if (device) this.startOtaForDevice(device);
+                    if (arr.length > 0) {
+                        // acknowledge the trigger
+                        await this.adapter.setStateAsync(`${this.adapter.namespace}.info.ota_available`, state.val, true);
+                        for (const devId of arr) {
+                            const entity = await this.zbController.resolveEntity(devId);
+                            if (entity) {
+                                await this.adapter.setStateAsync(`${this.adapter.namespace}.info.pairingMessage`, `Attempting OTA Update for device ${devId} (${entity.mapped?.model ?? ''})`, true);
+                                this.startOtaForEntity(entity);
+                            }
+                        }
+                        await this.adapter.setStateAsync(`${this.adapter.namespace}.info.ota_available`, JSON.stringify(Array.from(this.otaAvailable).map((ieee) => ieee.replace('0x', ''))), true);
                     }
-                    await this.adapter.setStateAsync(`${this.adapter.namespace}.info.ota_available`, JSON.stringify(Array.from(this.otaAvailable).map((ieee) => ieee.replace('0x', ''))), true);
                 } catch (error) {
                     this.warn(`value of info.ota_available does not parse (${error?.message ?? 'no message given'})`);
                 }
@@ -85,7 +96,7 @@ class Ota {
         }
     }
 
-    async deviceFromStateId(stateID) {
+    async entityFromStateId(stateID) {
         try {
             return await this.zbController.resolveEntity(stateID.replace(`${this.adapter.namespace}.`, '').split('.')[0]);
         }
@@ -95,23 +106,23 @@ class Ota {
     }
 
     async otafromState(devId, statedesc, command) {
-        const device = await this.zbController.resolveEntity(devId);
-        if (device) {
+        const entity = await this.zbController.resolveEntity(devId);
+        if (entity) {
             switch (command) {
                 case 'ota': {
-                    const result = await this.checkOtaforDevice(device);
+                    const result = await this.checkOtaforEntity(entity);
                     if (result.status == 'available')
-                        this.startOtaForDevice(device);
+                        this.startOtaForEntity(entity);
                     break;
                 }
                 case 'checkota':
                 case 'check_ota':
-                    await this.checkOtaforDevice(device);
+                    await this.checkOtaforEntity(entity);
                     break;
 
                 case 'startota':
                 case 'start_ota':
-                    this.startOtaForDevice(device)
+                    this.startOtaForEntity(entity)
                     break;
             }
             this.stController.emit('acknowledge_state', devId, '', statedesc, command);
@@ -125,9 +136,9 @@ class Ota {
         let upToDate=0;
         let updatable=0;
         for (const target of targets) {
-            const device = await this.zbController.resolveEntity(adIdtoZbIdorIeee(this.adapter, target));
-            if (!(device?.type == 'device' && device?.device?.type != 'Coordinator')) continue;
-            const result = await this.checkOtaforDevice(device);
+            const entity = await this.zbController.resolveEntity(adIdtoZbIdorIeee(this.adapter, target));
+            if (!(entity?.type == 'device' && entity?.device?.type != 'Coordinator')) continue;
+            const result = await this.checkOtaforEntity(entity);
             switch (result.status) {
                 case 'available':
                     updatable++;
@@ -142,8 +153,8 @@ class Ota {
         this.adapter.setStateAsync(`${this.adapter.namespace}.info.ota`, false, true);
     }
 
-    async startOtaForDevice(device) {
-        const devIeee = device?.device?.ieeeAddr ?? '0x0';
+    async startOtaForEntity(entity) {
+        const devIeee = entity?.device?.ieeeAddr ?? '0x0';
         const objID = zbIdorIeeetoAdId(this.adapter, devIeee, false)
         if (!this.otaAvailable.has(devIeee)) {
             const result = {};
@@ -167,13 +178,13 @@ class Ota {
             this.info(`Device ${devIeee} is marked unavailable, skipping ota check`);
             return;
         }
-        const result = { status: 'unknown', decice:device?.name ?? 'no name'};
-        this.inProgress.add(device.device.ieeeAddr);
+        const result = { status: 'unknown', decice:entity?.name ?? 'no name'};
+        this.inProgress.add(entity.device.ieeeAddr);
         try {
-            this.info('Start firmware update for ' + device.name);
+            this.info('Start firmware update for ' + entity.name);
 
             const onProgress = (progress, remaining) => {
-                let message = `Update of '${device.name}' at ${progress}%`;
+                let message = `Update of '${entity.name}' at ${progress}%`;
                 if (remaining) {
                     message += `, +- ${Math.round(remaining / 60)} minutes remaining`;
                 }
@@ -195,11 +206,11 @@ class Ota {
             };
             const endpoint = undefined // for future use ?
 
-            const [from, to] = await device.device.updateOta(
+            const [from, to] = await entity.device.updateOta(
                 source,
                 undefined, //Zcl.ClustersTypes.TClusterCommandPayload<"genOta", "queryNextImageRequest"> | undefined,
                 undefined,
-                typeof device.mapped.ota === 'object' ? device.mapped.ota : {},
+                typeof entity.mapped.ota === 'object' ? entity.mapped.ota : {},
                 onProgress,
                 dataSettings,
                 endpoint
@@ -208,18 +219,18 @@ class Ota {
             // const to = await this.readSoftwareBuildIDAndDateCode(device.device, true);
             const [fromS, toS] = [JSON.stringify(from), JSON.stringify(to)];
             result.status = 'success';
-            result.msg = `Finished update of '${device.name}'${to ? `, from '${fromS}' to '${toS}'` : ``} - reinterviewing the device`;
-            await device.device.interview(true);
+            result.msg = `Finished update of '${entity.name}'${to ? `, from '${fromS}' to '${toS}'` : ``} - reinterviewing the device`;
+            await entity.device.interview(true);
 
             this.info(result.msg);
         } catch (error) {
-            const message = `Update of '${device.name}' failed (${error.message})`;
+            const message = `Update of '${entity.name}' failed (${error.message})`;
             result.status = 'fail';
             result.msg = message;
             this.error(message);
         }
-        this.inProgress.delete(device.device.ieeeAddr);
-        this.otaAvailable.delete(device.device.ieeeAddr);
+        this.inProgress.delete(entity.device.ieeeAddr);
+        this.otaAvailable.delete(entity.device.ieeeAddr);
         await this.adapter.setStateAsync(`${this.adapter.namespace}.info.ota_available`, JSON.stringify(Array.from(this.otaAvailable).map((ieee) => ieee.replace('0x', ''))), true);
         return result;
     }
@@ -259,8 +270,8 @@ class Ota {
         return '';
     }
 
-    async checkOtaforDevice(device) {
-        const ieeeAddr = device?.device?.ieeeAddr ?? `0x0`;
+    async checkOtaforEntity(entity) {
+        const ieeeAddr = entity?.device?.ieeeAddr ?? `0x0`;
         const result = {status: 'unknown', device: ieeeAddr};
         const msg = await this.checkDeviceObjects(ieeeAddr);
         if (msg != '') {
@@ -270,13 +281,13 @@ class Ota {
         }
         this.inProgress.add(ieeeAddr);
         try {
-            this.debug(`Checking if firmware update is available for ${device.name}`);
+            this.debug(`Checking if firmware update is available for ${entity.name}`);
 
-            if (device && device.mapped.ota) {
-                const available = await device.device.checkOta({ downgrade:false }, undefined, typeof device.mapped.ota === 'object' ? device.mapped.ota : {}, undefined);
+            if (entity && entity.mapped.ota) {
+                const available = await entity.device.checkOta({ downgrade:false }, undefined, typeof entity.mapped.ota === 'object' ? entity.mapped.ota : {}, undefined);
                 result.status = available.available ? 'available' : 'not_available';
                 if (available.currentFileVersion !== available.otaFileVersion) {
-                    this.debug(`current Firmware for ${device.name} is ${available.currentFileVersion} new is ${available.otaFileVersion}`);
+                    this.debug(`current Firmware for ${entity.name} is ${available.currentFileVersion} new is ${available.otaFileVersion}`);
                 }
             } else {
                 result.status = 'not_supported';
@@ -315,7 +326,7 @@ class Ota {
                 return false;
             }
             // do not attempt update for a device which has been deactivated or is unavailable
-            result = await this.checkOtaforDevice(device);
+            result = await this.checkOtaforEntity(device);
         }
         this.adapter.sendTo(obj.from, obj.command, result, obj.callback);
     }
@@ -328,7 +339,7 @@ class Ota {
             msg: 'Device is unavailable'
         }
         if (device) {
-            result = await this.startOtaForDevice(device)
+            result = await this.startOtaForEntity(device)
         }
         else {
             this.debug(`Device ${obj.message.devId} is unavailable`);

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -90,8 +90,13 @@ class DeviceAvailability extends BaseExtension {
     }
 
     async getAllPingableDevices() {
-        const clients = await this.zigbee.getClients();
-        return clients.filter(d => this.isPingable(d));
+        const result = [];
+        for (const d of await this.zigbee.getClientIterator()) {
+            if (this.isPingable(d)) result.push(d);
+        }
+        return result;
+        //const clients = await this.zigbee.getClients();
+        //return clients.filter(d => this.isPingable(d));
     }
 
     async registerDevicePing(device, entity) {
@@ -191,7 +196,7 @@ class DeviceAvailability extends BaseExtension {
         const has_elevated_debug = this.checkDebugDevice(device.ieeeAddr)
 
         const ieeeAddr = device.ieeeAddr;
-        const resolvedEntity = entity ? entity : await this.zigbee.resolveEntity(ieeeAddr);
+        const resolvedEntity = entity ?? await this.zigbee.resolveEntity(device);
         if (!resolvedEntity) {
             const msg = `Stop pinging '${ieeeAddr}' ${device.modelID}, device is not known anymore`
             if (has_elevated_debug) this.warn(`ELEVADED: ${msg}`);
@@ -302,8 +307,11 @@ class DeviceAvailability extends BaseExtension {
         for (const timer of Object.values(this.timers)) {
             clearTimeout(timer);
         }
-        const clients = await this.zigbee.getClients();
-        clients.forEach(device => this.publishAvailability(device, false));
+        for (const device of this.zigbee.getClientIterator()) {
+            this.publishAvailability(device, false);
+        }
+        //const clients = await this.zigbee.getClients();
+        //clients.forEach(device => this.publishAvailability(device, false));
     }
 
     async onReconnect(device) {

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -95,8 +95,6 @@ class DeviceAvailability extends BaseExtension {
             if (this.isPingable(d)) result.push(d);
         }
         return result;
-        //const clients = await this.zigbee.getClients();
-        //return clients.filter(d => this.isPingable(d));
     }
 
     async registerDevicePing(device, entity) {
@@ -310,8 +308,6 @@ class DeviceAvailability extends BaseExtension {
         for (const device of this.zigbee.getClientIterator()) {
             this.publishAvailability(device, false);
         }
-        //const clients = await this.zigbee.getClients();
-        //clients.forEach(device => this.publishAvailability(device, false));
     }
 
     async onReconnect(device) {

--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -3,8 +3,6 @@
 const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
 const BaseExtension = require('./zbBaseExtension');
 
-const forcedConfigureOnEachStart = ['V3-BTZB','014G2461','SPZB0001','ZK03840'];
-
 class DeviceConfigure extends BaseExtension {
     constructor(zigbee, options) {
         super(zigbee, options);
@@ -85,15 +83,11 @@ class DeviceConfigure extends BaseExtension {
         try {
             this.coordinatorEndpoint = await this.zigbee.getDevicesByType('Coordinator')[0].endpoints[0];
 
-            for (const device of await this.zigbee.getClients()) {
+            for (const device of await this.zigbee.getClientIterator()) {
                 const mappedDevice = await zigbeeHerdsmanConverters.findByDevice(device);
-                if (forcedConfigureOnEachStart.find((d) => d && d.hasOwnProperty('zigbeeModel') && d.zigbeeModel.includes(device.modelID))) {
-                    this.debug(`DeviceConfigure ${device.ieeeAddr} ${mappedDevice ? mappedDevice.model : device.modelID} forced by adapter config`);
-                    device.meta.configured = -1; // Force a reconfiguration for this device
-                }
                 if (this.shouldConfigure(device, mappedDevice)) {
                     this.info(`DeviceConfigure ${device.ieeeAddr} ${mappedDevice ? mappedDevice.model : device.modelID} needed - Device added to Configuration Queue`);
-                    await this.PushDeviceToQueue(device, mappedDevice);
+                    this.PushDeviceToQueue(device, mappedDevice);
                 } else {
                     this.debug(`DeviceConfigure ${device.ieeeAddr} ${mappedDevice ? mappedDevice.model : device.modelID} not needed`);
                 }

--- a/lib/zbDeviceEvent.js
+++ b/lib/zbDeviceEvent.js
@@ -27,10 +27,8 @@ class DeviceEvent extends BaseExtension {
     }
 
     async stop() {
-        if (this.zigbee.getClients() > 0) {
-            for (const device of await this.zigbee.getClients()) {
-                await this.callOnEvent(device, 'stop', {ieeeAddr:device.ieeeAddr});
-            }
+        for (const device of await this.zigbee.getClientIterator()) {
+            await this.callOnEvent(device, 'stop', {ieeeAddr:device.ieeeAddr});
         }
     }
 

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -309,7 +309,6 @@ class ZigbeeController extends EventEmitter {
                     this.debug('failed to resolve Entity for ' + device.ieeeAddr);
                     continue;
                 }
-                //await this.adapter.stController.AddModelFromHerdsman(device, entity.mapped.model);
 
                 this.adapter.getObject(utils.zbIdorIeeetoAdId(this.adapter, device.ieeeAddr, false), (err, obj) => {
                     if (obj && obj.common && obj.common.deactivated) {
@@ -336,7 +335,6 @@ class ZigbeeController extends EventEmitter {
             }
 
             // Log zigbee clients on startup
-            // const devices = await this.getClients();
             const gm = Groups.length > 0 ? `and ${Groups.length} group${Groups.length > 1?'s':''} ` : '';
             const m = deviceCount > 0 ? `${deviceCount} devices ${gm}are part of the network` : `No devices ${gm}`;
             this.info(m);
@@ -407,21 +405,6 @@ class ZigbeeController extends EventEmitter {
         }
         return Promise.all(result);
     }
-
-    /*
-    async getClients(all) {
-        if (this.herdsman.database) {
-            const devices = this.getClientIterator(all);
-            if (all) {
-                return devices;
-            } else {
-                return devices.filter(device => device.type !== 'Coordinator');
-            }
-        } else {
-            return [];
-        }
-    }
-    */
 
     getClientIterator(all) {
         if (this.herdsman.database) {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -408,6 +408,7 @@ class ZigbeeController extends EventEmitter {
         return Promise.all(result);
     }
 
+    /*
     async getClients(all) {
         if (this.herdsman.database) {
             const devices = this.getClientIterator(all);
@@ -420,6 +421,7 @@ class ZigbeeController extends EventEmitter {
             return [];
         }
     }
+    */
 
     getClientIterator(all) {
         if (this.herdsman.database) {
@@ -492,6 +494,8 @@ class ZigbeeController extends EventEmitter {
                     break;
                 case 'startota':
                 case 'checkota':
+                case 'start_ota':
+                case 'check_ota':
                 case 'ota':
                     actionResult = { ignored:true };
                     this.adapter.callPluginMethod('otafromState', [devId, statedesc, command]);
@@ -853,7 +857,7 @@ class ZigbeeController extends EventEmitter {
                     mapped,
                     endpoint,
                     endpoints: device.endpoints,
-                    name: device.ieeeAddr,
+                    name: mapped?.model ?? device.modelID,
                     options:options
                 };
             }
@@ -987,7 +991,7 @@ class ZigbeeController extends EventEmitter {
     }
 
     // Remove device
-    async remove(deviceID, force, callback) {
+    async remove(deviceID, force) {
         try {
             const device = this.herdsman.getDeviceByIeeeAddr(deviceID);
             if (device) {
@@ -1015,7 +1019,6 @@ class ZigbeeController extends EventEmitter {
                         if (this.debugActive) this.debug(`Failed to remove from DB ${error.stack}`);
                 }
                 if (this.debugActive) this.debug('Remove successful.');
-                callback && callback();
                 this.callExtensionMethod(
                     'onDeviceRemove',
                     [device],
@@ -1032,9 +1035,9 @@ class ZigbeeController extends EventEmitter {
 
             }
             const msg = `Failed to remove ${deviceID ? 'device ' + deviceID : 'unspecified device'}: ${message}`;
-            if (callback) callback(msg); else return { status:false, error:msg};
+            return { status:false, error:msg};
         }
-        if (!callback) return {status:true};
+        return {status:true};
     }
 
 
@@ -1263,9 +1266,9 @@ class ZigbeeController extends EventEmitter {
                     });
                     continue;
                 }
-                let resolved = await this.resolveEntity(device, 0);
-                if (!resolved) {
-                    resolved = { name:'unresolved device', device:device }
+                let entity = await this.resolveEntity(device, 0);
+                if (!entity) {
+                    entity = { name:'unresolved device', device:device }
                     if (this.debugActive) this.debug('resolve Entity failed for ' + device.ieeeAddr)
                 }
 
@@ -1282,7 +1285,7 @@ class ZigbeeController extends EventEmitter {
                             if (dev !== undefined && ieeeAddr !== '0xffffffffffffffff') {
                                 const lq = (dev.linkquality == undefined) ? dev.lqi== undefined ? 0 : dev.lqi : dev.linkquality
                                 lqis.push({
-                                    parent: (resolved ? resolved.device.ieeeAddr : undefined),
+                                    parent: (entity ? entity.device.ieeeAddr : undefined),
                                     networkAddress: dev.networkAddress || dev.nwkAddress,
                                     ieeeAddr: ieeeAddr,
                                     lqi: lq,
@@ -1296,7 +1299,7 @@ class ZigbeeController extends EventEmitter {
                 } catch (error) {
                     MapData.edev.push(device.ieeeAddr);
                     const eReason = this.filterHerdsmanError(error.message);
-                    errors.push(`Failed to execute LQI for '${resolved ? resolved.name : 'unresolved device'} (${resolved ? resolved.device.modelID : 'unknown'}') : ${eReason}.`);
+                    errors.push(`Failed to execute LQI for '${entity ? entity.name : 'unresolved device'} (${entity ? entity.device.modelID : 'unknown'}') : ${eReason}.`);
                     attemptRouting = eReason != 'Timeout'
                     lqis.push({
                         parent: 'undefined',
@@ -1316,7 +1319,7 @@ class ZigbeeController extends EventEmitter {
                     if (r_arr !== undefined) {
                         for (const dev of r_arr) {
                             routing.push({
-                                source: resolved.device.ieeeAddr,
+                                source: entity.device.ieeeAddr,
                                 destination: dev.destinationAddress,
                                 nextHop: dev.nextHop ? dev.nextHop: dev.nextHopAddress,
                                 status: dev.status,
@@ -1326,10 +1329,10 @@ class ZigbeeController extends EventEmitter {
                 } catch (error) {
                     MapData.edev.push(`routing ${device.ieeeAddr}`);
                     if (error) {
-                        errors.push(`Failed to collect routing table for '${resolved?.name || 'unresolved device'} (${resolved?.device?.modelID || 'unknown'}') : ${this.filterHerdsmanError(error.message)}`);
+                        errors.push(`Failed to collect routing table for '${entity?.name || 'unresolved device'} (${entity?.device?.modelID || 'unknown'}') : ${this.filterHerdsmanError(error.message)}`);
                     }
                 }
-                else errors.push(`Omitted collecting routing table for '${resolved?.name || 'unresolved device'} (${resolved?.device?.modelID ||'unknown'}') : LQI timed out`);
+                else errors.push(`Omitted collecting routing table for '${entity?.name || 'unresolved device'} (${entity?.device?.modelID ||'unknown'}') : LQI timed out`);
                 this.emit('pairing', `Map Devices left: ${cnt}`);
             }
             this.emit('pairing', 'Map data collection complete');
@@ -2014,25 +2017,33 @@ class ZigbeeController extends EventEmitter {
         let entity; // needed to have access to entity outside in the catch path.
         try {
             entity = await this.resolveEntity(devId);
-            const group = await this.resolveEntity(groupId);
+            const group = await this.resolveEntity(groupId)?.mapped;
 
-            if (epid != undefined) {
-                for (const ep of entity.endpoints) {
-                    if (this.debugActive) this.debug(`checking ep ${ep.ID} of ${devId} (${epid})`);
-                    if (ep.ID == epid && (ep.inputClusters.includes(4) || ep.outputClusters.includes(4))) {
-                        await ep.removeFromGroup(group.mapped);
-                        this.info(`removing endpoint ${ep.ID} of ${devId} from group ${groupId}`);
+            if (group) {
+                if (epid != undefined) {
+                    for (const ep of entity.endpoints) {
+                        if (this.debugActive) this.debug(`checking ep ${ep.ID} of ${devId} (${epid})`);
+                        if (ep.ID == epid && (ep.inputClusters.includes(4) || ep.outputClusters.includes(4))) {
+                            await ep.removeFromGroup(group);
+                            this.info(`removing endpoint ${ep.ID} of ${devId} from group ${groupId}`);
+                        }
                     }
+                } else {
+                    await entity.endpoint.removeFromGroup(group);
+                    this.info(`removing endpoint ${entity.endpoint.ID} of ${devId} from group ${groupId}`);
                 }
-            } else {
-                await entity.endpoint.removeFromGroup(group.mapped);
-                this.info(`removing endpoint ${entity.endpoint.ID} of ${devId} from group ${groupId}`);
+            }
+            else {
+                const msg = `Unable to resolve group ${groupId} when removing ${devId} (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group`
+                this.error(msg);
+                return {error: msg};
             }
 
         } catch (error) {
             this.sendError(error);
-            this.error(`Exception when trying remove ${devId} (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group ${devId}`, error);
-            return {error: `Failed to remove dev ${devId} (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group ${devId}`};
+            const msg = `Exception when trying remove ${devId} (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group ${devId}`
+            this.error(msg, error);
+            return {error: msg};
         }
         return {};
     }

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1249,10 +1249,9 @@ class ZigbeeController extends EventEmitter {
                     });
                     continue;
                 }
-                let entity = await this.resolveEntity(device, 0);
-                if (!entity) {
-                    entity = { name:'unresolved device', device:device }
-                    if (this.debugActive) this.debug('resolve Entity failed for ' + device.ieeeAddr)
+                const entity = await this.resolveEntity(device, 0) ?? { name:'unresolved device', device:device };
+                if (entity.name === 'unresolved device' && this.debugActive) {
+                    this.debug('resolve Entity failed for ' + device.ieeeAddr)
                 }
 
                 let attemptRouting = true;
@@ -1282,7 +1281,7 @@ class ZigbeeController extends EventEmitter {
                 } catch (error) {
                     MapData.edev.push(device.ieeeAddr);
                     const eReason = this.filterHerdsmanError(error.message);
-                    errors.push(`Failed to execute LQI for '${entity ? entity.name : 'unresolved device'} (${entity ? entity.device.modelID : 'unknown'}') : ${eReason}.`);
+                    errors.push(`Failed to execute LQI for '${entity?.name ?? 'unresolved device'} (${entity?.device?.modelID ??'unknown'}') : ${eReason}.`);
                     attemptRouting = eReason != 'Timeout'
                     lqis.push({
                         parent: 'undefined',
@@ -1312,10 +1311,10 @@ class ZigbeeController extends EventEmitter {
                 } catch (error) {
                     MapData.edev.push(`routing ${device.ieeeAddr}`);
                     if (error) {
-                        errors.push(`Failed to collect routing table for '${entity?.name || 'unresolved device'} (${entity?.device?.modelID || 'unknown'}') : ${this.filterHerdsmanError(error.message)}`);
+                        errors.push(`Failed to collect routing table for '${entity?.name ?? 'unresolved device'} (${entity?.device?.modelID ?? 'unknown'}') : ${this.filterHerdsmanError(error.message)}`);
                     }
                 }
-                else errors.push(`Omitted collecting routing table for '${entity?.name || 'unresolved device'} (${entity?.device?.modelID ||'unknown'}') : LQI timed out`);
+                else errors.push(`Omitted collecting routing table for '${entity?.name ?? 'unresolved device'} (${entity?.device?.modelID ??'unknown'}') : LQI timed out`);
                 this.emit('pairing', `Map Devices left: ${cnt}`);
             }
             this.emit('pairing', 'Map data collection complete');

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1251,7 +1251,7 @@ class ZigbeeController extends EventEmitter {
                 }
                 const entity = await this.resolveEntity(device, 0) ?? { name:'unresolved device', device:device };
                 if (entity.name === 'unresolved device' && this.debugActive) {
-                    this.debug('resolve Entity failed for ' + device.ieeeAddr)
+                    this.debug('resolve Entity failed for ' + device.ieeeAddr);
                 }
 
                 let attemptRouting = true;

--- a/main.js
+++ b/main.js
@@ -444,7 +444,7 @@ class Zigbee extends adapterCore.Adapter {
         const response = {};
         if (this.reconnectTimer) this.clearTimeout(this.reconnectTimer);
         this.reconnectTimer = null;
-        const zo = message.zigbeeOptions || {};
+        const zo = message?.zigbeeOptions ?? {};
         if (message.start) {
             try {
                 const keys = Object.keys(zo);


### PR DESCRIPTION
- removed ReconfigureOnStart (no longer needed)
- removed getClients from zbcontroller - use getClientIterator instead
- modified 'deleteDevice' command handling
- removed `callback` parameter from zbcontroller.remove (this now needs to be called with `await`)
- modified OTA handling
- global rename: Variable name for the result of `resoveEntity` is `entity` or one fitting to its purpose (i.e. `source` and `target` in case of bindings, no longer `device`
