### PR TITLE
fix: crash-loop on startup device query (missing device arg to endpoint())

### DIFF
--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -174,7 +174,9 @@ class DeviceAvailability extends BaseExtension {
         if (this.startReadDelay > 0 && readables.length > 0) {
             this.debug(`Triggering device_query on ${readables.length} devices in ${this.startReadDelay / 1000} seconds.`)
             setTimeout(() => {
-                readables.forEach(device => this.zigbee.doDeviceQuery(device, Date.now(), false));
+                readables.forEach(device =>
+                    this.zigbee.doDeviceQuery(device, Date.now(), false).catch(error =>
+                        this.warn(`device query for '${device.ieeeAddr}' failed: ${error && error.message ? error.message : error}`)));
             }, this.startReadDelay)
         }
     }

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1885,7 +1885,7 @@ class ZigbeeController extends EventEmitter {
         if (this.debugActive) this.debug(`doDeviceQuery: resolveEntity for entity: ${deviceId} is ${safeJsonStringify(utils.entityData(entity))}`);
         const mappedModel = entity ? entity.mapped : undefined;
         if (mappedModel) {
-            const epmap = mappedModel.endpoint ? mappedModel.endpoint() : [];
+            const epmap = mappedModel.endpoint ? mappedModel.endpoint(entity.device) : [];
             if (elevated) {
                 const message  = `Device query for '${entity.device.ieeeAddr}' triggered`;
                 this.emit('device_debug', { ID:debugID, data: { flag: 'qs' ,states:[{id:'device_query', value:true, payload:'device_query'}], IO:false }, message:message});


### PR DESCRIPTION
## Problem

After updating to 3.4.11 the adapter goes into a restart loop on startup (#2919):

```
TypeError: Cannot use 'in' operator to search for 'isDummyDevice' in undefined
    at Object.isDummyDevice (zigbee-herdsman-converters/dist/lib/utils.js:711)
    at shellySwitchInputEndpoints (zigbee-herdsman-converters/dist/devices/shelly.js)
    at Object.endpoint (zigbee-herdsman-converters/dist/devices/shelly.js)
    at ZigbeeController.doDeviceQuery (lib/zigbeecontroller.js:1888)
```

The throw happens inside ZHC, but it is triggered from the adapter: `doDeviceQuery()` calls the device definition's `endpoint()` **without the device argument**, whereas the two other call sites pass it — `lib/zigbeecontroller.js:840` (`mapped.endpoint(device)`) and `:1839` (`mappedModel.endpoint(entity.device)`):

```js
const epmap = mappedModel.endpoint ? mappedModel.endpoint() : [];   // device missing
```

With newer `zigbee-herdsman-converters` (here 26.74.0), definitions whose `endpoint(device)` actually uses the device now dereference it — for Shelly via `shellySwitchInputEndpoints(device, …)` → `utils.isDummyDevice(device)` → `"isDummyDevice" in device`. With `device === undefined` the `in` operator throws. Older ZHC ignored the argument, so the argument-less call was harmless before — this is ZHC API drift and is **not Shelly-specific**; it affects any definition whose `endpoint(device)` reads the device.

The startup device query runs fire-and-forget (`zbDeviceAvailability.js`, `forEach` inside a `setTimeout`, no `await`/`catch`), so the throw becomes an unhandled promise rejection and takes the whole adapter down → restart loop. (A downgrade of the adapter alone does not recover, because the already-installed ZHC is unchanged.)

## Changes

1. **`lib/zigbeecontroller.js`** — pass `entity.device` to `mappedModel.endpoint()` in `doDeviceQuery`, matching the other two call sites. Besides fixing the crash this makes `epmap` correct for multi-endpoint devices, since the endpoint map is filtered via `device.getEndpoint()`.
2. **`lib/zbDeviceAvailability.js`** (defense-in-depth) — attach a `.catch()` to the fire-and-forget startup device query so a single device's failure is logged instead of crash-looping the adapter.

Commit 1 is the actual fix; commit 2 is independent hardening and can be dropped if you'd rather keep the PR minimal.

## Testing

Verified on a productive installation that reproduced the crash (affected Shelly Gen4 devices present, ZHC 26.74.0 / ZH 10.5.0):

- before: restart loop, `isDummyDevice` TypeError on every startup device query
- after: adapter starts and stays connected, device queries (including the Shelly devices) complete, no `isDummyDevice` error
- `node --check` passes on both changed files

Addresses #2919
