### PR TITLE
fix: deleting a device unknown to the controller always reports an error

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -391,8 +391,8 @@ class Commands {
             if (!dev) {
 
                 this.info(`Attempted to delete device ${devId} - the device is not known to the zigbee controller.`);
-                const err = await this.stController.deleteObj(devId);
-                if (err != '') this.adapter.sendTo(from, command, {error:err}, callback);
+                const objDelete = await this.stController.deleteObj(devId);
+                if (!objDelete.status) this.adapter.sendTo(from, command, {error: objDelete.message}, callback);
                 else this.adapter.sendTo(from, command, {}, callback);
                 return;
             }


### PR DESCRIPTION
## Problem

Deleting a device that is no longer known to the zigbee controller — e.g. an orphaned device whose ioBroker objects remain after it dropped out of the network — always reports an error in the admin UI, even though the objects are deleted successfully.

## Cause

In `deleteZigbeeDevice` (`lib/commands.js`), the "device not known to the controller" branch still checks the result of `deleteObj()` as a string:

```js
const err = await this.stController.deleteObj(devId);
if (err != '') this.adapter.sendTo(from, command, {error:err}, callback);
```

But `deleteObj()` returns an object `{status, message}` (success is `{status:true}`). An object is never `== ''`, so this branch always takes the error path — and sends the raw result object as the error payload.

The main deletion path in the same function already handles the object shape correctly (`objDelete.status` / `objDelete.message`); this branch was missed when `deleteObj` was migrated to return an object.

## Fix

Mirror the main path:

```js
const objDelete = await this.stController.deleteObj(devId);
if (!objDelete.status) this.adapter.sendTo(from, command, {error: objDelete.message}, callback);
else this.adapter.sendTo(from, command, {}, callback);
```

## Testing

- `node --check` passes.
- The branch is reached when deleting a device that is absent from herdsman but still has ioBroker objects; with the fix a successful object deletion reports no error, and a real failure reports `objDelete.message`.

Follow-up to #2907 (completes the `deleteObj` object-result migration).
