### PR TITLE
Use public device.modelID instead of internal _modelID (legacy WXKG11LM selector)

### DIFF
--- a/lib/legacy/devices.js
+++ b/lib/legacy/devices.js
@@ -629,7 +629,7 @@ const legacy_devices = [
         models: ['WXKG11LM'],
         icon: 'img/aqara_switch.png',
         states: (entity) => {
-            if (entity.device._modelID === 'lumi.sensor_switch.aq2') {
+            if (entity.device.modelID === 'lumi.sensor_switch.aq2') {
                 return [
                     states.click, states.double_click, states.triple_click, states.quad_click,
                     states.voltage, states.battery


### PR DESCRIPTION
The `_modelID` point from the #2922 review (an internal property that should not be addressed directly) applies to one more active site outside that PR's scope: the legacy WXKG11LM state-selector in `lib/legacy/devices.js` branches on `entity.device._modelID` to detect the `lumi.sensor_switch.aq2` variant.

`_modelID` is a zigbee-herdsman internal; the public `device.modelID` getter returns the same value and is already the accessor used everywhere else in the adapter (`commands.js`, `utils.js`, `zbDelayedAction.js`, …). Swapped to the public form — behaviour-identical, no functional change.

Related to #2922.
