### PR TITLE
feat: show the user-assigned device name in log messages

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { getZbId, getNetAddress, reverseByteString, zbIdorIeeetoAdId, adIdtoZbIdorIeee } = require('./utils');
+const { getZbId, reverseByteString } = require('./utils');
+const { devLabel } = require('./deviceLabel');
 const fs = require('fs');
 const localConfig = require('./localConfig.js');
 const colors = require('./colors.js');
@@ -390,13 +391,13 @@ class Commands {
             const dev = this.zbController.getDevice(sysid);
             if (!dev) {
 
-                this.info(`Attempted to delete device ${devId} - the device is not known to the zigbee controller.`);
+                this.info(`Attempted to delete device '${devLabel(this.adapter, devId)}' - the device is not known to the zigbee controller.`);
                 const objDelete = await this.stController.deleteObj(devId);
                 if (!objDelete.status) this.adapter.sendTo(from, command, {error: objDelete.message}, callback);
                 else this.adapter.sendTo(from, command, {}, callback);
                 return;
             }
-            this.info(`${force ? 'Force removing' : 'Gracefully removing '} device ${devId} from the network.`);
+            this.info(`${force ? 'Force removing' : 'Gracefully removing '} device '${devLabel(this.adapter, devId)}' from the network.`);
 
             const result = {};
             const devDelete = await this.zbController.remove(sysid, force);
@@ -619,7 +620,7 @@ class Commands {
             this.adapter.sendTo(from, command, result , callback);
             /*
             const devid = getZbId(msg.id);
-            this.debug(`Reconfigure ${devid}`);
+            this.debug(`Reconfigure '${devLabel(this.adapter, devid)}'`);
             const entity = await this.zbController.resolveEntity(devid);
             if (entity) {
                 try {

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ZigbeeHerdsman = require('zigbee-herdsman');
+const { devLabel } = require('./deviceLabel');
 
 
 class Developer {
@@ -117,11 +118,11 @@ class Developer {
             try {
                 publishTarget = await this.zbController.getDevice(devId) ? devId : await this.zbController.getGroup(parseInt(devId));
                 if (!publishTarget) {
-                    if (obj.callback) this.adapter.sendTo(obj.from, obj.command, {localErr: `Device or group ${devId} not found!`}, obj.callback);
+                    if (obj.callback) this.adapter.sendTo(obj.from, obj.command, {localErr: `Device or group '${devLabel(this.adapter, devId)}' not found!`}, obj.callback);
                     return;
                 }
             } catch (error) {
-                this.error(`SendToZigbee failed from publishTarget ${devId} (${error && error.message ? error.message : 'no details given'})`);
+                this.error(`SendToZigbee failed from publishTarget '${devLabel(this.adapter, devId)}' (${error && error.message ? error.message : 'no details given'})`);
             }
 
             if (!cid || !cmd) {

--- a/lib/deviceLabel.js
+++ b/lib/deviceLabel.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const utils = require('./utils');
+
+/**
+ * Resolve a device log label from any id/IEEE/group-id form. Looks up the user-assigned name via
+ * the adapter's state controller (falling back to the model as default when the user has not
+ * renamed the device); the id is always kept for unique identification (see
+ * utils.deviceDisplayName). Never throws — a log line can never fail because of this. An invalid
+ * id resolves to "unknown device" (via deviceDisplayName), a lookup failure to "failed to get name".
+ *
+ * Lives in its own module (not in utils) so that utils stays free of adapter-specific code.
+ *
+ * @param {object} adapter the ioBroker adapter instance (needs .stController.verifyDeviceName)
+ * @param {string|number} idOrIeee the device id / IEEE address / group id (always shown in the label)
+ * @param {string} [model] the device model — per-model override key and default name when un-named
+ * @returns {string} the display label ("name (id)"), or "failed to get name (id)" on error
+ */
+function devLabel(adapter, idOrIeee, model) {
+    let name = 'unnamed';
+    try {
+        const adId = utils.zbIdorIeeetoAdId(adapter, idOrIeee, false);
+        if (adapter && adapter.stController && typeof adapter.stController.verifyDeviceName === 'function') {
+            name = adapter.stController.verifyDeviceName(adId, model, model);
+        }
+    } catch {
+        return `failed to get name (${idOrIeee})`;
+    }
+    return utils.deviceDisplayName(idOrIeee, name);
+}
+
+module.exports = { devLabel };

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -4,6 +4,7 @@ const json = require('./json');
 const stateDefinitions = require('./models');
 const idRegExp = new RegExp(/group_(\d+)/);
 const { entityData, getZbId , getAdId } = require('./utils');
+const { devLabel } = require('./deviceLabel');
 
 
 class Groups {
@@ -240,7 +241,7 @@ class Groups {
         if (!mappedModel) return;
         const obj = await this.adapter.getObjectAsync((member.ieee.includes('x') ? member.ieee.split('x')[1] : member.ieee));
         if (obj && obj.common.deactivated) {
-            this.debug(`omitting reading member state for deactivated device ${member.ieee}`);
+            this.debug(`omitting reading member state for deactivated device '${devLabel(this.adapter, member.ieee)}'`);
             return;
         }
         const converter = mappedModel.toZigbee.find(c => c && (c.key.includes(item.state)));
@@ -249,10 +250,10 @@ class Groups {
             try {
                 await converter.convertGet(endpoint, item.state, {device:entity.device});
             } catch (error) {
-                this.debug(`reading ${item.state} from ${member.id}${member.ieee ? '/' + member.epid : ''} via convertGet failed with ${error && error.message ? error.message : 'no reason given'}`);
+                this.debug(`reading ${item.state} from '${devLabel(this.adapter, member.id)}'${member.ieee ? '/' + member.epid : ''} via convertGet failed with ${error && error.message ? error.message : 'no reason given'}`);
                 return {unread:member.device};
             }
-            this.debug(`reading ${item.state} from ${member.ieee}${member.ep ? '/' + member.epid : ''} via convertGet succeeded` );
+            this.debug(`reading ${item.state} from '${devLabel(this.adapter, member.ieee)}'${member.ep ? '/' + member.epid : ''} via convertGet succeeded` );
             return {read:member.device};
         }
         if (toRead.cluster) {
@@ -260,17 +261,17 @@ class Groups {
                 if (entity.endpoint.inputClusters.includes(toRead.cluster)) {
                     try {
                         const result = await endpoint.read(toRead.cluster, toRead.attributes,{disableDefaultResponse : true });
-                        this.debug(`readGroupMemberStatus for ${item.state} from ${member.ieee}${member.ep ? '/' + member.epid : ''} resulted in ${JSON.stringify(result)}`);
+                        this.debug(`readGroupMemberStatus for ${item.state} from '${devLabel(this.adapter, member.ieee)}'${member.ep ? '/' + member.epid : ''} resulted in ${JSON.stringify(result)}`);
                     }
                     catch (error) {
-                        this.debug(`reading ${item.state} from ${member.ieee}${member.ep ? '/' + member.epid : ''} via endpoint.read with ${toRead.cluster}, ${JSON.stringify(toRead.attributes)} resulted in ${error && error.message ? error.message : 'an unspecified error'}`);
+                        this.debug(`reading ${item.state} from '${devLabel(this.adapter, member.ieee)}'${member.ep ? '/' + member.epid : ''} via endpoint.read with ${toRead.cluster}, ${JSON.stringify(toRead.attributes)} resulted in ${error && error.message ? error.message : 'an unspecified error'}`);
                     }
-                    this.debug(`reading ${item.state} from ${member.ieee}${member.ep ? '/' + member.epid : ''} via endpoint.read with ${toRead.cluster}, ${JSON.stringify(toRead.attributes)} succeeded`);
+                    this.debug(`reading ${item.state} from '${devLabel(this.adapter, member.ieee)}'${member.ep ? '/' + member.epid : ''} via endpoint.read with ${toRead.cluster}, ${JSON.stringify(toRead.attributes)} succeeded`);
                 }
                 else this.debug(`omitting cluster ${toRead.cluster} - not supported`);
             }
             else {
-                this.debug(`unable to read ${item.state} from ${member.id}${member.ep ? '/' + member.epid : ''} - unable to resolve the entity`);
+                this.debug(`unable to read ${item.state} from '${devLabel(this.adapter, member.id)}'${member.ep ? '/' + member.epid : ''} - unable to resolve the entity`);
             }
             return;
         }
@@ -461,7 +462,7 @@ class Groups {
             if (message.remove) {
                 for (const member of message.remove) {
                     const response = await this.zbController.removeDevFromGroup(member.id, id, member.ep);
-                    this.debug('trying to remove ' + member.id + (member.ep ? '.'+member.ep : '') + ' ' + ' from group ' + message.id + ' response is '+JSON.stringify(response));
+                    this.debug('trying to remove ' + "'" + devLabel(this.adapter, member.id) + "'" + (member.ep ? '.'+member.ep : '') + ' ' + ' from group ' + message.id + ' response is '+JSON.stringify(response));
                 }
             }
         } catch (e) {

--- a/lib/ota.js
+++ b/lib/ota.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { getZbId , zbIdorIeeetoAdId, adIdtoZbIdorIeee} = require('./utils');
+const { getZbId , zbIdorIeeetoAdId, adIdtoZbIdorIeee } = require('./utils');
+const { devLabel } = require('./deviceLabel');
 const {setOtaConfiguration} = require('zigbee-herdsman');
 const fs = require('fs');
 const path = require('node:path');
@@ -163,28 +164,28 @@ class Ota {
             return result;
         }
         if (this.inProgress.has(devIeee)) {
-            this.error(`Update or check already in progress for '${devIeee}', skipping...`);
+            this.error(`Update or check already in progress for '${devLabel(this.adapter, devIeee)}', skipping...`);
             return;
         }
         // do not attempt update for a device which has been deactivated or is unavailable
         const stateObj = await this.adapter.getObjectAsync(objID);
         if (stateObj && stateObj.common && stateObj.common.deactivated) {
-            this.info(`Device ${devIeee} is deactivated, skipping ota check`);
+            this.info(`Device '${devLabel(this.adapter, devIeee)}' is deactivated, skipping ota check`);
             return;
         }
         const availablestate = await this.adapter.getStateAsync(`${objID}.available`);
         const lqi = await this.adapter.getStateAsync(`${objID}.link_quality`);
         if ((availablestate && (!availablestate.val)) || (lqi && lqi.val < 1)) {
-            this.info(`Device ${devIeee} is marked unavailable, skipping ota check`);
+            this.info(`Device '${devLabel(this.adapter, devIeee)}' is marked unavailable, skipping ota check`);
             return;
         }
         const result = { status: 'unknown', decice:entity?.name ?? 'no name'};
         this.inProgress.add(entity.device.ieeeAddr);
         try {
-            this.info('Start firmware update for ' + entity.name);
+            this.info('Start firmware update for ' + "'" + devLabel(this.adapter, entity.device.ieeeAddr) + "'");
 
             const onProgress = (progress, remaining) => {
-                let message = `Update of '${entity.name}' at ${progress}%`;
+                let message = `Update of '${devLabel(this.adapter, entity.device.ieeeAddr)}' at ${progress}%`;
                 if (remaining) {
                     message += `, +- ${Math.round(remaining / 60)} minutes remaining`;
                 }
@@ -224,7 +225,7 @@ class Ota {
 
             this.info(result.msg);
         } catch (error) {
-            const message = `Update of '${entity.name}' failed (${error.message})`;
+            const message = `Update of '${devLabel(this.adapter, entity.device.ieeeAddr)}' failed (${error.message})`;
             result.status = 'fail';
             result.msg = message;
             this.error(message);
@@ -258,13 +259,13 @@ class Ota {
         const objID = zbIdorIeeetoAdId(this.adapter, ieeeAddr, false)
         const obj = await this.adapter.getObjectAsync(objID);
         if ((obj ?? true) && obj?.common?.deactivated) {
-            this.info(`Device ${ieeeAddr} is deactivated, skipping ota check`);
+            this.info(`Device '${devLabel(this.adapter, ieeeAddr)}' is deactivated, skipping ota check`);
             return 'deactivated';
         }
         const availablestate = await this.adapter.getStateAsync(`${objID}.available`);
         const lqi = await this.adapter.getStateAsync(`${objID}.link_quality`);
         if ((availablestate && (!availablestate.val)) || (lqi && lqi.val < 1)) {
-            this.info(`Device ${ieeeAddr} is marked unavailable, skipping ota check`);
+            this.info(`Device '${devLabel(this.adapter, ieeeAddr)}' is marked unavailable, skipping ota check`);
             return 'unavailable';
         };
         return '';
@@ -281,20 +282,20 @@ class Ota {
         }
         this.inProgress.add(ieeeAddr);
         try {
-            this.debug(`Checking if firmware update is available for ${entity.name}`);
+            this.debug(`Checking if firmware update is available for '${devLabel(this.adapter, ieeeAddr)}'`);
 
             if (entity && entity.mapped.ota) {
                 const available = await entity.device.checkOta({ downgrade:false }, undefined, typeof entity.mapped.ota === 'object' ? entity.mapped.ota : {}, undefined);
                 result.status = available.available ? 'available' : 'not_available';
                 if (available.currentFileVersion !== available.otaFileVersion) {
-                    this.debug(`current Firmware for ${entity.name} is ${available.currentFileVersion} new is ${available.otaFileVersion}`);
+                    this.debug(`current Firmware for '${devLabel(this.adapter, ieeeAddr)}' is ${available.currentFileVersion} new is ${available.otaFileVersion}`);
                 }
             } else {
                 result.status = 'not_supported';
             }
-            this.debug(`Firmware update for ${ieeeAddr} is ${result.status}`);
+            this.debug(`Firmware update for '${devLabel(this.adapter, ieeeAddr)}' is ${result.status}`);
         } catch (error) {
-            const message = `Failed to check if update available for '${ieeeAddr}' ${error.message}`;
+            const message = `Failed to check if update available for '${devLabel(this.adapter, ieeeAddr)}' ${error.message}`;
             result.status = 'fail';
             result.msg = message;
             if (!message.includes(`Device didn't respond to OTA request`)) this.warn(message);
@@ -342,7 +343,7 @@ class Ota {
             result = await this.startOtaForEntity(device)
         }
         else {
-            this.debug(`Device ${obj.message.devId} is unavailable`);
+            this.debug(`Device '${devLabel(this.adapter, obj.message.devId)}' is unavailable`);
         }
         this.adapter.sendTo(obj.from, obj.command, result, obj.callback)
     }

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -11,6 +11,7 @@ const zigbeeHerdsmanConvertersUtils = require('zigbee-herdsman-converters/lib/ut
 
 /// adapter defined functions and structures
 const utils = require('./utils');
+const { devLabel } = require('./deviceLabel');
 const modelDefinitions = require('./models');
 const safeJsonStringify = require('./json');
 
@@ -95,10 +96,10 @@ class StatesController extends EventEmitter {
     }
 
     leaveDevice(ieeeAddr, model) {
-        this.debug(`Leave device event: ${ieeeAddr}`);
+        this.debug(`Leave device event: '${this.devLabel(ieeeAddr)}'`);
         if (ieeeAddr) {
             const devId = utils.zbIdorIeeetoAdId(this, ieeeAddr, false);
-            this.debug(`Delete device ${devId} from iobroker.`);
+            this.debug(`Delete device '${this.devLabel(devId)}' from iobroker.`);
             this.deleteObj(devId);
         }
     }
@@ -343,7 +344,7 @@ class StatesController extends EventEmitter {
 
                     if (model && model.id === 'device_query') {
                         if (this.query_device_block.indexOf(deviceId) > -1 && !state.source.includes('.admin.')) {
-                            this.info(`Device query for '${deviceId}' blocked - device query timeout has not elapsed yet.`);
+                            this.info(`Device query for '${this.devLabel(deviceId)}' blocked - device query timeout has not elapsed yet.`);
                             return;
                         }
                         this.emit('device_query', { deviceId, debugId });
@@ -383,7 +384,7 @@ class StatesController extends EventEmitter {
                     this.adapter.getState(id, (err, state) => {
                         cnt = cnt + 1;
                         if (!err && state) {
-                            this.debug(`collect options for ${devId}:  ${JSON.stringify(result)}`);
+                            this.debug(`collect options for '${this.devLabel(devId)}':  ${JSON.stringify(result)}`);
                             result[statedesc.id] = statedesc.setter ?  statedesc.setter(state.val) : state.val;
                         }
                         if (cnt === len) {
@@ -396,11 +397,11 @@ class StatesController extends EventEmitter {
                 }
             } catch (error) {
                 this.sendError(error);
-                this.error(`Error collectOptions for ${devId}. Error: ${error.stack}`);
+                this.error(`Error collectOptions for '${this.devLabel(devId)}'. Error: ${error.stack}`);
             }
         }
         catch (error) {
-            this.error(`Error in collectOptions for ${devId} , ${model} : ${error && error.message ? error.message : 'no message given'}`);
+            this.error(`Error in collectOptions for '${this.devLabel(devId)}' , ${model} : ${error && error.message ? error.message : 'no message given'}`);
             callback({});
 
         }
@@ -433,7 +434,7 @@ class StatesController extends EventEmitter {
             return {states, stateModel};
         } catch (error) {
             this.sendError(error);
-            this.error(`Error getDevStates for ${deviceId}. Error: ${error.stack}`);
+            this.error(`Error getDevStates for '${this.devLabel(deviceId)}'. Error: ${error.stack}`);
         }
     }
 
@@ -575,18 +576,18 @@ class StatesController extends EventEmitter {
     }
 
     async publishFromState(deviceId, model, stateKey, state, options, debugID) {
-        if (this.debugActive) this.debug(`Change state '${stateKey}' at device ${deviceId} type '${model}'`);
+        if (this.debugActive) this.debug(`Change state '${stateKey}' at device '${this.devLabel(deviceId)}' type '${model}'`);
         const has_elevated_debug = this.checkDebugDevice(typeof deviceId == 'number' ? `group_${deviceId}` : deviceId);
 
         if (has_elevated_debug)  {
-            const message = (`Change state '${stateKey}' at device ${deviceId} type '${model}'`);
+            const message = (`Change state '${stateKey}' at device '${this.devLabel(deviceId)}' type '${model}'`);
             this.emit('device_debug', { ID:debugID, data: { ID: deviceId, model: model, flag:'02', IO:false }, message:message});
         }
 
         const devStates = await this.getDevStates(deviceId, model);
         if (!devStates) {
             if (has_elevated_debug) {
-                const message = (`no device states for device ${deviceId} type '${model}'`);
+                const message = (`no device states for device '${this.devLabel(deviceId)}' type '${model}'`);
                 this.emit('device_debug', { ID:debugID, data: { error: 'NOSTATES' , IO:false }, message:message});
             }
             return;
@@ -602,7 +603,7 @@ class StatesController extends EventEmitter {
         const value = state.val;
         if (value === undefined || value === '') {
             if (has_elevated_debug) {
-                const message = (`no value for device ${deviceId} type '${model}'`);
+                const message = (`no value for device '${this.devLabel(deviceId)}' type '${model}'`);
                 this.emit('device_debug', { ID:debugID, data: { states:[{id:state.ID, value:'--', payload:'error', ep:stateDesc.epname}],error: 'NOVAL1' , IO:false }, message:message});
             }
             return;
@@ -721,6 +722,11 @@ class StatesController extends EventEmitter {
         return this.localConfig.NameForId(id, model, name);
     }
 
+    // Log label for a device: user-assigned name if set, otherwise the id/address.
+    devLabel(idOrIeee, model) {
+        return devLabel(this.adapter, idOrIeee, model);
+    }
+
 
     setDeviceActivated(id, inActive) {
         this.adapter.extendObject(id, {common: {deactivated: inActive, color:inActive ? '#888888' : null, statusStates: inActive ? null : {onlineId:`${id}.available`} }});
@@ -743,7 +749,7 @@ class StatesController extends EventEmitter {
             await this.adapter.delObjectAsync(devId,options);
             return {status:true};
         } catch (error) {
-            this.adapter.log.warn(`Cannot delete Object ${devId}: ${error && error.message ? error.message : 'without error message'}`);
+            this.adapter.log.warn(`Cannot delete Object '${this.devLabel(devId)}': ${error && error.message ? error.message : 'without error message'}`);
             return { status:false, message: `Cannot delete Object ${devId}: ${error && error.message ? error.message : 'without error message'}`};
         }
     }
@@ -787,8 +793,8 @@ class StatesController extends EventEmitter {
                     ) {
                         this.cleanupRequired |= markOnly;
                         if (state.common.hasOwnProperty('custom') && !force && !markOnly) {
-                            messages.push(`keeping disconnected state ${JSON.stringify(statename)} of ${devId} `)
-                            this.info(`keeping disconnected state ${JSON.stringify(statename)} of ${devId} `);
+                            messages.push(`keeping disconnected state ${JSON.stringify(statename)} of '${this.devLabel(devId)}' `)
+                            this.info(`keeping disconnected state ${JSON.stringify(statename)} of '${this.devLabel(devId)}' `);
                             this.cleanupRequired = true;
                         } else {
                             if (markOnly) {
@@ -798,19 +804,19 @@ class StatesController extends EventEmitter {
                             else
                             {
                                 try {
-                                    this.info(`deleting disconnected state ${JSON.stringify(statename)} of ${devId} `);
-                                    messages.push(`deleting disconnected state ${JSON.stringify(statename)} of ${devId} `);
+                                    this.info(`deleting disconnected state ${JSON.stringify(statename)} of '${this.devLabel(devId)}' `);
+                                    messages.push(`deleting disconnected state ${JSON.stringify(statename)} of '${this.devLabel(devId)}' `);
                                     this.deleteObj(devId.concat('.',statename));
                                 }
                                 catch (error) {
-                                    //messages.push(`ERROR: failed to delete state ${JSON.stringify(statename)} of ${devId} `)
+                                    //messages.push(`ERROR: failed to delete state ${JSON.stringify(statename)} of '${this.devLabel(devId)}' `)
                                 }
                             }
                         }
                     } else {
                         if (!markOnly) {
-                            if (this.debugActive) this.debug(`keeping connected state ${JSON.stringify(statename)} of  ${devId} `);
-                            messages.push(`keeping connecte state ${JSON.stringify(statename)} of  ${devId} `);
+                            if (this.debugActive) this.debug(`keeping connected state ${JSON.stringify(statename)} of  '${this.devLabel(devId)}' `);
+                            messages.push(`keeping connecte state ${JSON.stringify(statename)} of  '${this.devLabel(devId)}' `);
                         }
                     }
                 });
@@ -991,7 +997,7 @@ class StatesController extends EventEmitter {
     async updateDev(dev_id, dev_name, model) {
 
         const __dev_name = this.verifyDeviceName(dev_id, model, (dev_name ? dev_name : model));
-        if (this.debugActive) this.debug(`UpdateDev called with ${dev_id}, ${dev_name}, ${model}, ${__dev_name}`);
+        if (this.debugActive) this.debug(`UpdateDev called with '${this.devLabel(dev_id)}', ${dev_name}, ${model}, ${__dev_name}`);
         const id = '' + dev_id;
         const objId = model=='group' ? `group_${dev_id}` : dev_id;
         const obj = await this.adapter.getObjectAsync(objId);
@@ -1100,7 +1106,7 @@ class StatesController extends EventEmitter {
     }
 
     async syncDevStates(dev, model) {
-        if (this.debugActive) this.debug('synchronizing device states for ' + dev.ieeeAddr + ' (' + model + ')');
+        if (this.debugActive) this.debug('synchronizing device states for ' + "'" + this.devLabel(dev.ieeeAddr) + "'" + ' (' + model + ')');
         const devId = utils.zbIdorIeeetoAdId(this.adapter, dev.ieeeAddr, false);
         // devId - iobroker device id
         const devStates = await this.getDevStates(dev.ieeeAddr, model);
@@ -1189,13 +1195,13 @@ class StatesController extends EventEmitter {
 
         // checking value
         if (value === undefined || value === null) {
-            const message = `value '${JSON.stringify(value)}' from device ${devId} via ${mode} for '${statedesc.name} (ID ${statedesc.id} ${statedesc.prop ? 'with property '+statedesc.prop : ''})`;
+            const message = `value '${JSON.stringify(value)}' from device '${this.devLabel(devId)}' via ${mode} for '${statedesc.name} (ID ${statedesc.id} ${statedesc.prop ? 'with property '+statedesc.prop : ''})`;
             if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data: { states:[{id:stateID, value:value, payload:payload }],flag:'04', IO:true }, message});
             else if (this.debugActive) this.debug(message);
             return {};
         }
 
-        const message = `value generated '${typeof(value) == 'object' ? JSON.stringify(value) : value}' from device ${devId} for '${statedesc.name}'`;
+        const message = `value generated '${typeof(value) == 'object' ? JSON.stringify(value) : value}' from device '${this.devLabel(devId)}' for '${statedesc.name}'`;
         if (statedesc.id != 'msg_from_zigbee' && has_elevated_debug ) {
             this.emit('device_debug', { ID:debugId, data: { states:[{id:stateID, value:value, payload:payload }],flag:'04', IO:true }, message});
         }
@@ -1254,14 +1260,14 @@ class StatesController extends EventEmitter {
 
             const has_elevated_debug = (this.checkDebugDevice(devId) && !payload.hasOwnProperty('msg_from_zigbee'));
 
-            const message = `message received '${JSON.stringify(payload)}' from device ${devId} type '${model}'`;
+            const message = `message received '${JSON.stringify(payload)}' from device '${this.devLabel(devId)}' type '${model}'`;
 
             if (has_elevated_debug)
                 this.emit('device_debug', { ID:debugId, data: { deviceID: devId, flag:'03', IO:true }, message:message});
             else
                 if (this.debugActive) this.debug(message);
             if (!devStates) {
-                const message = `no device states for device ${devId} type '${model}'`;
+                const message = `no device states for device '${this.devLabel(devId)}' type '${model}'`;
                 if (has_elevated_debug)this.emit('device_debug', { ID:debugId, data: { error:'NOSTATE',states:[{ id:'--', value:'--', payload:payload}], IO:true }, message:message});
                 else if (this.debugActive) this.debug(message);
                 return undefined;
@@ -1279,18 +1285,18 @@ class StatesController extends EventEmitter {
                             publishedStates[publishResult.key] = publishResult.value;
                     }
                 } catch (e) {
-                    const message = `unable to enumerate states of ${devId} for payload ${JSON.stringify(payload)}, ${(e ? e.name : 'undefined')} (${(e ? e.message : '')}).`;
+                    const message = `unable to enumerate states of '${this.devLabel(devId)}' for payload ${JSON.stringify(payload)}, ${(e ? e.name : 'undefined')} (${(e ? e.message : '')}).`;
                     if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data:{ error:'ESTATE', IO:true }, message:message});
                     else if (this.debugActive) this.debug(message);
                 }
-                const message = `No value published for device ${devId}`;
+                const message = `No value published for device '${this.devLabel(devId)}'`;
                 if (Object.keys(publishedStates).length == 0) {
                     if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data:{ states:[{id:'no state', value:'no value', inError:true, payload:payload }], flag:'04', IO:true }, message:message});
                     else if (this.debugActive) this.debug(message);
                 }
             }
             else {
-                const message = `ELEVATED IE05 - NOSTATE: No states matching the payload ${JSON.stringify(payload)} for device ${devId}`;
+                const message = `ELEVATED IE05 - NOSTATE: No states matching the payload ${JSON.stringify(payload)} for device '${this.devLabel(devId)}'`;
                 if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data:{ error:'NOSTATE', IO:true }, message});
                 else if (this.debugActive) this.debug(message);
             }
@@ -1381,7 +1387,7 @@ class StatesController extends EventEmitter {
                     else resolve({});
                 }
                 catch (error) {
-                    const msg = `Error while processing converters DEVICE_ID: '${devId}' cluster '${converter.cluster}' type '${converter.type}' ${error && error.message ? ' message: ' + error.message : ''}`;
+                    const msg = `Error while processing converters DEVICE_ID: '${this.devLabel(devId)}' cluster '${converter.cluster}' type '${converter.type}' ${error && error.message ? ' message: ' + error.message : ''}`;
                     if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data: { error:'EPROC', IO:true }, message: `${msg} - ${error?.stack ?? 'no stack available'}` });
                     this.warn(msg);
                     resolve ({})
@@ -1428,7 +1434,7 @@ class StatesController extends EventEmitter {
         const has_elevated_debug = this.checkDebugDevice(devId);
         const debugId = Date.now();
         if (entity.device.interviewing) {
-            this.debug(`zigbee event for ${device.ieeeAddr} received during interview!`);
+            this.debug(`zigbee event for '${this.devLabel(device.ieeeAddr)}' received during interview!`);
             return;
         }
 
@@ -1502,7 +1508,7 @@ class StatesController extends EventEmitter {
             }
         }
         if (has_elevated_debug) {
-            const message = `Zigbee Event of Type ${type} from device ${device.ieeeAddr}, incoming event: ${safeJsonStringify(msgForState)}`;
+            const message = `Zigbee Event of Type ${type} from device '${this.devLabel(device.ieeeAddr)}', incoming event: ${safeJsonStringify(msgForState)}`;
             this.emit('device_debug', { ID:debugId, data: { ID: device.ieeeAddr, payload:safeJsonStringify(msgForState), flag:'01', IO:true }, message:message});
 
         }
@@ -1575,13 +1581,13 @@ class StatesController extends EventEmitter {
         }
 
         if (has_elevated_debug) {
-            const message = `${converters.length} converter${converters.length > 1 ? 's' : ''} available for '${mappedModel.model}' '${devId}' with cluster '${cluster}' and type '${type}'`
+            const message = `${converters.length} converter${converters.length > 1 ? 's' : ''} available for '${mappedModel.model}' '${this.devLabel(devId)}' with cluster '${cluster}' and type '${type}'`;
             this.emit('device_debug', { ID:debugId, data: { flag:'02', IO:true }, message:message})
         }
 
         if (!converters.length) {
             if (type !== 'readResponse' && type !== 'commandQueryNextImageRequest') {
-                const message = `No converter available for '${mappedModel.model}' '${devId}' with cluster '${cluster}' and type '${type}'`;
+                const message = `No converter available for '${mappedModel.model}' '${this.devLabel(devId)}' with cluster '${cluster}' and type '${type}'`;
                 if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data: { error:'NOCONV', IO:true }, message:message});
                 else if (this.debugActive) this.debug(message);
             }
@@ -1620,7 +1626,7 @@ class StatesController extends EventEmitter {
             //   'Error: Expected one of: 0, 1, got: 'undefined''
             if (cluster !== '64529') {
                 if (has_elevated_debug) this.emit('device_debug', { ID:debugId, data: { error:'EPROC', IO:true }});
-                this.error(`Error while processing converters DEVICE_ID: '${devId}' cluster '${cluster}' type '${type}'`);
+                this.error(`Error while processing converters DEVICE_ID: '${this.devLabel(devId)}' cluster '${cluster}' type '${type}'`);
                 this.error(`error message: ${error && error.message ? error.message : ''}`);
             }
         }
@@ -1663,13 +1669,13 @@ class StatesController extends EventEmitter {
                 }
             }
             if (changed) {
-                this.warn(`Statescontroller updated meta for ${devId} from ${message} to ${JSON.stringify(existingMeta)}`);
+                this.warn(`Statescontroller updated meta for '${this.devLabel(devId)}' from ${message} to ${JSON.stringify(existingMeta)}`);
                 await this.adapter.extendObject(devId, {native: { meta: existingMeta }});
             }
-            // else this.warn(`Statescontroller  no update meta for ${devId} => meta was unchanged (${JSON.stringify(m)})`);
+            // else this.warn(`Statescontroller  no update meta for '${this.devLabel(devId)}' => meta was unchanged (${JSON.stringify(m)})`);
         }
         catch (error) {
-            this.warn(`Statescontroller error updating meta for ${devId} : ${error?.message ?? 'no error message given'}`);
+            this.warn(`Statescontroller error updating meta for '${this.devLabel(devId)}' : ${error?.message ?? 'no error message given'}`);
         }
     }
     */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -188,6 +188,32 @@ function zbIdorIeeetoAdId(adapter, source, withNamespace) {
     return `${preface}${source}`;
 }
 
+/**
+ * Pure formatter for a device log label: the user-assigned name if one is set, otherwise the
+ * raw id/address. Keeps device log lines readable ("Küche - Boiler") while still identifying
+ * un-named devices by their address.
+ * @param {string} idOrIeee the device id or IEEE address (e.g. "0x1234…")
+ * @param {string|null|undefined} givenName the user-assigned device name, or null/empty when unset
+ * @returns {string} the display label
+ */
+/**
+ * Pure formatter for a device log label: the user-assigned name plus the id/address, which always
+ * stays for unique identification (the IEEE is the only truly unique and unchangeable info). The id
+ * may be a string (IEEE) or a number (a group id, after ZH/ZHC changes). A device without a valid
+ * id should not exist, so that path yields "unknown device"; a valid id without a name yields
+ * "unnamed (id)". Never throws.
+ * @param {string|number} idOrIeee the device id / IEEE address / group id (always shown)
+ * @param {string|undefined|null} givenName the resolved name, or nullish when unknown
+ * @returns {string} e.g. "Living room lamp (0x00158d0001abcd)", "unnamed (5)" or "unknown device"
+ */
+function deviceDisplayName(idOrIeee, givenName) {
+    if (typeof idOrIeee !== 'string' && typeof idOrIeee !== 'number') {
+        return 'unknown device';
+    }
+    const name = typeof givenName === 'string' ? givenName.trim() : '';
+    return name ? `${name} (${idOrIeee})` : `unnamed (${idOrIeee})`;
+}
+
 function adIdtoZbIdorIeee(adapter, source) {
     const s = `${source}`.replace(`${adapter.namespace}.`, '');
     if (s.startsWith('group')) return Number(s.substring(6));
@@ -392,6 +418,7 @@ exports.byteArrayToString       = byteArrayToString;
 exports.reverseByteString       = reverseByteString;
 exports.adIdtoZbIdorIeee        = adIdtoZbIdorIeee;
 exports.zbIdorIeeetoAdId        = zbIdorIeeetoAdId;
+exports.deviceDisplayName       = deviceDisplayName;
 exports.removeFromArray         = removeFromArray;
 exports.getMetaStates           = getMetaStates;
 exports.getMeta                 = getMetaFromAdapter;

--- a/lib/zbBaseExtension.js
+++ b/lib/zbBaseExtension.js
@@ -2,6 +2,8 @@
 
 /*eslint no-unused-vars: ['off']*/
 
+const { devLabel } = require('./deviceLabel');
+
 class BaseExtension {
     constructor(zigbee, options) {
         this.zigbee = zigbee;
@@ -26,6 +28,11 @@ class BaseExtension {
             this.zigbee.warn(`DE ${this.name}:${message}`, data);
         else
             this.zigbee.debug(`${this.name}:${message}`, data);
+    }
+
+    // Log label for a device: user-assigned name if set, otherwise the id/address.
+    devLabel(idOrIeee, model) {
+        return devLabel(this.zigbee.adapter, idOrIeee, model);
     }
 
     pairingMessage(message) {

--- a/lib/zbDelayedAction.js
+++ b/lib/zbDelayedAction.js
@@ -66,12 +66,12 @@ class DelayedAction extends BaseExtension {
                 attempts: 0,
                 action: action,
             });
-            this.debug(`Succesfully delay action for ${device.ieeeAddr} ${device.modelID}`);
+            this.debug(`Succesfully delay action for '${this.devLabel(device.ieeeAddr)}'`);
             this.doActions(device);
         } catch (error) {
             this.sendError(error);
             this.error(
-                `Failed to DelayedAction.delayAction ${device.ieeeAddr} ${device.modelID} (${error.stack})`,
+                `Failed to DelayedAction.delayAction '${this.devLabel(device.ieeeAddr)}' (${error.stack})`,
             );
         }
     }
@@ -83,7 +83,7 @@ class DelayedAction extends BaseExtension {
             }
             const foundDev = await this.zigbee.getDevice(device.ieeeAddr);
             if (!foundDev) {
-                this.debug(`No found device ${device.ieeeAddr} ${device.modelID}, for doAction`);
+                this.debug(`No found device '${this.devLabel(device.ieeeAddr)}', for doAction`);
                 delete this.actions[device.ieeeAddr];
                 return;
             }
@@ -99,16 +99,16 @@ class DelayedAction extends BaseExtension {
                     continue;
                 }
                 actionDef.inAction = true;
-                this.debug(`Do action on ${device.ieeeAddr} ${device.modelID}`);
+                this.debug(`Do action on '${this.devLabel(device.ieeeAddr)}'`);
                 try {
                     // do action
                     await actionDef.action(device);
-                    this.info(`Do action successfully ${device.ieeeAddr} ${device.modelID}`);
+                    this.info(`Do action successfully '${this.devLabel(device.ieeeAddr)}'`);
                     toDelete.push(actionDef);
                 } catch (error) {
                     this.sendError(error);
                     this.error(
-                        `Failed to do action ${device.ieeeAddr} ${device.modelID}, ` +
+                        `Failed to do action '${this.devLabel(device.ieeeAddr)}', ` +
                         `attempt ${actionDef.attempts + 1} (${error.stack})`,
                     );
                     actionDef.attempts++;
@@ -126,7 +126,7 @@ class DelayedAction extends BaseExtension {
         } catch (error) {
             this.sendError(error);
             this.error(
-                `Failed to DelayedAction.doAction ${device.ieeeAddr} ${device.modelID} (${error.stack})`,
+                `Failed to DelayedAction.doAction '${this.devLabel(device.ieeeAddr)}' (${error.stack})`,
             );
         }
     }

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -99,7 +99,7 @@ class DeviceAvailability extends BaseExtension {
 
     async registerDevicePing(device, entity) {
         if (!this.isStarted) return;
-        this.debug(`register device Ping for ${JSON.stringify(device.ieeeAddr)}`);
+        this.debug(`register device Ping for '${this.devLabel(device.ieeeAddr)}'`);
         this.forcedNonPingable[device.ieeeAddr] = false;
         if (!this.isPingable(device)) {
             return;
@@ -112,7 +112,7 @@ class DeviceAvailability extends BaseExtension {
             }
         });
         this.number_of_registered_devices++;
-        this.debug(`registering device Ping (${this.number_of_registered_devices}) for ${device.ieeeAddr} (${device.modelID})`);
+        this.debug(`registering device Ping (${this.number_of_registered_devices}) for '${this.devLabel(device.ieeeAddr)}'`);
         this.availability_timeout = Math.max(Math.min(this.number_of_registered_devices * AverageTimeBetweenPings, MaxAvailabilityTimeout), MinAvailabilityTimeout);
         this.startDevicePingQueue.push({device, entity});
         if (this.startDevicePingTimeout == null) {
@@ -122,7 +122,7 @@ class DeviceAvailability extends BaseExtension {
     }
 
     async deregisterDevicePing(device) {
-        this.debug(`deregister device Ping for deactivated device ${JSON.stringify(device.ieeeAddr)}`);
+        this.debug(`deregister device Ping for deactivated device '${this.devLabel(device.ieeeAddr)}'`);
         this.forcedNonPingable[device.ieeeAddr] = true;
         if (this.timers[device.ieeeAddr]) {
             clearTimeout(this.timers[device.ieeeAddr]);
@@ -165,7 +165,7 @@ class DeviceAvailability extends BaseExtension {
                 readables.push(device);
                 //                this.setTimerPingable(device);
             } else {
-                this.debug(`Setting '${device.ieeeAddr}'  as available - battery driven or no active availability check`);
+                this.debug(`Setting '${this.devLabel(device.ieeeAddr)}'  as available - battery driven or no active availability check`);
                 this.publishAvailability(device, true);
                 this.timers[device.ieeeAddr] = setInterval(() =>
                     this.handleIntervalNotPingable(device), utils.secondsToMilliseconds(this.availability_timeout));
@@ -176,7 +176,7 @@ class DeviceAvailability extends BaseExtension {
             setTimeout(() => {
                 readables.forEach(device =>
                     this.zigbee.doDeviceQuery(device, Date.now(), false).catch(error =>
-                        this.warn(`device query for '${device.ieeeAddr}' failed: ${error && error.message ? error.message : error}`)));
+                        this.warn(`device query for '${this.devLabel(device.ieeeAddr)}' failed: ${error && error.message ? error.message : error}`)));
             }, this.startReadDelay)
         }
     }
@@ -198,7 +198,7 @@ class DeviceAvailability extends BaseExtension {
         const ieeeAddr = device.ieeeAddr;
         const resolvedEntity = entity ?? await this.zigbee.resolveEntity(device);
         if (!resolvedEntity) {
-            const msg = `Stop pinging '${ieeeAddr}' ${device.modelID}, device is not known anymore`
+            const msg = `Stop pinging '${this.devLabel(ieeeAddr)}' ${device.modelID}, device is not known anymore`
             if (has_elevated_debug) this.warn(`ELEVADED: ${msg}`);
             else this.info(msg);
             return;
@@ -212,7 +212,7 @@ class DeviceAvailability extends BaseExtension {
             }
             try {
                 if (!this.pingCluster || !this.pingCluster.hasOwnProperty('id')) {
-                    const message = `Pinging '${ieeeAddr}' (${device.modelID}) via ZH Ping`
+                    const message = `Pinging '${this.devLabel(ieeeAddr)}' (${device.modelID}) via ZH Ping`
                     if (has_elevated_debug) {
                         this.zigbee.emit('device_debug', { ID:debugID, data: { ID: device.ieeeAddr, flag:'PI', IO:false, states:[{ id:'ping', value: 'zh_default', payload: { method:'default'}}]}, message:message});
                     }
@@ -222,7 +222,7 @@ class DeviceAvailability extends BaseExtension {
                 else {
                     const zclData = {};
                     zclData[this.pingCluster.attribute] = {};
-                    const message = `Pinging '${ieeeAddr}' (${device.modelID}) via ZCL Read with ${this.pingCluster.id}:${this.pingCluster.attribute}`
+                    const message = `Pinging '${this.devLabel(ieeeAddr)}' (${device.modelID}) via ZCL Read with ${this.pingCluster.id}:${this.pingCluster.attribute}`
                     if (has_elevated_debug) {
                         this.zigbee.emit('device_debug', { ID:debugID, data: { ID: device.ieeeAddr, flag:'PI', states:[{id:'ping', value:'cluster/id', payload: { method: 'custom', cluster:this.pingCluster.id, command:'read', zcl:zclData}}], IO:false}, message:message});
                     }
@@ -231,7 +231,7 @@ class DeviceAvailability extends BaseExtension {
                 }
                 this.publishAvailability(device, true, false, has_elevated_debug ? debugID : undefined);
                 if (has_elevated_debug) {
-                    const message = `Successfully pinged ${ieeeAddr} (${device.modelID}) in ${Date.now()-debugID} ms`
+                    const message = `Successfully pinged '${this.devLabel(ieeeAddr)}' in ${Date.now()-debugID} ms`
                     this.zigbee.emit('device_debug', { ID:debugID, data: {ID: device.ieeeAddr, flag:'SUCCESS', IO:false}, message:message});
                 }
                 this.setTimerPingable(device, 1);
@@ -241,16 +241,16 @@ class DeviceAvailability extends BaseExtension {
                     // this error is acceptable, as it is raised off an answer of the device.
                     this.publishAvailability(device, true);
                     if (has_elevated_debug)
-                        this.zigbee.emit('device_debug', {  ID:debugID, data: {ID: device.ieeeAddr, flag:'SUCCESS', IO:false}, message:`Successfully pinged ${ieeeAddr} (${device.modelID}) in ${Date.now()-debugID} ms`});
+                        this.zigbee.emit('device_debug', {  ID:debugID, data: {ID: device.ieeeAddr, flag:'SUCCESS', IO:false}, message:`Successfully pinged '${this.devLabel(ieeeAddr)}' in ${Date.now()-debugID} ms`});
                     this.setTimerPingable(device, 1);
                     this.ping_counters[device.ieeeAddr].failed = 0;
                     return;
                 }
                 if (has_elevated_debug)
-                    this.zigbee.emit('device_debug',{ ID:debugID, data: {ID: device.ieeeAddr, error:'PIFAIL', IO:false}, message:`Failed to ping ${ieeeAddr} (${device.modelID}) after ${Date.now()-debugID} ms${error && error.message ? ' - '+error.message : ''}`});
+                    this.zigbee.emit('device_debug',{ ID:debugID, data: {ID: device.ieeeAddr, error:'PIFAIL', IO:false}, message:`Failed to ping '${this.devLabel(ieeeAddr)}' after ${Date.now()-debugID} ms${error && error.message ? ' - '+error.message : ''}`});
                 this.publishAvailability(device, false, false, has_elevated_debug ? debugID : undefined);
                 if (pingCount.failed++ <= this.max_ping) {
-                    const message = `Failed to ping ${ieeeAddr} ${device.modelID} for ${JSON.stringify(pingCount)} attempts`
+                    const message = `Failed to ping '${this.devLabel(ieeeAddr)}' for ${JSON.stringify(pingCount)} attempts`
                     if (pingCount.reported < this.max_ping) {
                         if (!has_elevated_debug)
                             this.info(message);
@@ -261,7 +261,7 @@ class DeviceAvailability extends BaseExtension {
                     this.setTimerPingable(device, pingCount.failed);
                     this.ping_counters[device.ieeeAddr] = pingCount;
                 } else {
-                    const msg = `Stopping to ping ${ieeeAddr} ${device.modelID} after ${pingCount.failed} ping attempts`;
+                    const msg = `Stopping to ping '${this.devLabel(ieeeAddr)}' after ${pingCount.failed} ping attempts`;
                     if (has_elevated_debug)
                         this.zigbee.emit('device_debug',{ ID:debugID, data: {ID: device.ieeeAddr, error:'PISTOP', IO:false}, message:msg});
                     else
@@ -282,11 +282,11 @@ class DeviceAvailability extends BaseExtension {
 
         if (ago > Hours25) {
             this.publishAvailability(entity.device, false);
-            const msg = `Non-pingable device ${entity.device.ieeeAddr} ${entity.device.modelID} was last seen over 25 hrs ago - setting it offline.`
+            const msg = `Non-pingable device '${this.devLabel(entity.device.ieeeAddr)}' was last seen over 25 hrs ago - setting it offline.`
             if (this.checkDebugDevice(device.ieeeAddr)) this.warn(`ELEVATED: ${msg}`); else this.debug(msg);
             return;
         }
-        const msg = `Non-pingable device ${entity.device.ieeeAddr} ${entity.device.modelID} was last seen '${ago / 1000}' seconds ago.`
+        const msg = `Non-pingable device '${this.devLabel(entity.device.ieeeAddr)}' was last seen '${ago / 1000}' seconds ago.`
         if (this.checkDebugDevice(device.ieeeAddr)) this.warn(`ELEVATED: ${msg}`); else this.debug(msg);
     }
 
@@ -326,7 +326,7 @@ class DeviceAvailability extends BaseExtension {
                 }
             } catch (error) {
                 this.sendError(error);
-                this.debug(`Failed to read state of '${entity.device.ieeeAddr}' after reconnect`);
+                this.debug(`Failed to read state of '${this.devLabel(entity.device.ieeeAddr)}' after reconnect`);
             }
         }
     }
@@ -351,10 +351,10 @@ class DeviceAvailability extends BaseExtension {
                     available
                 }
                 const payload = {available: available};
-                this.debug(`Publish available for ${ieeeAddr} = ${available}`);
+                this.debug(`Publish available for '${this.devLabel(ieeeAddr)}' = ${available}`);
                 this.zigbee.emit('publish', utils.zbIdorIeeetoAdId(this.zigbee, ieeeAddr, false), entity.mapped.model, payload);
                 if (force || (astate.available !== available)) {
-                    this.debug(`Publish LQ for ${ieeeAddr} = ${(available ? 10 : 0)}`);
+                    this.debug(`Publish LQ for '${this.devLabel(ieeeAddr)}' = ${(available ? 10 : 0)}`);
                     this.zigbee.emit('publish', utils.zbIdorIeeetoAdId(this.adapter, ieeeAddr, false), entity.mapped.model, {linkquality: (available ? 10 : 0)});
                 }
             }

--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -32,7 +32,7 @@ class DeviceConfigure extends BaseExtension {
             return;
         }
         const configureItem = this.deviceConfigureQueue.shift();
-        this.info(`DeviceConfigureQueue configuring ${configureItem.dev.ieeeAddr} ${configureItem.dev.modelID}`)
+        this.info(`DeviceConfigureQueue configuring '${this.devLabel(configureItem.dev.ieeeAddr)}'`)
         this.doConfigure(configureItem.dev, configureItem.mapped);
     }
 
@@ -75,7 +75,7 @@ class DeviceConfigure extends BaseExtension {
         const t = Date.now();
         const cfgkey = definitionVersion;
         const result = device.meta.hasOwnProperty('configured') && device.meta.configured !== cfgkey && definitionVersion != '0.0.0';
-        this.debug(`should configure for device ${device.ieeeAddr} (${mappedDevice.model}: ${device.meta.hasOwnProperty('configured') ? device.meta.configured: 'none'} -  ${cfgkey} (query took ${Date.now()- t} ms)`);
+        this.debug(`should configure for device '${this.devLabel(device.ieeeAddr)}' (${mappedDevice.model}: ${device.meta.hasOwnProperty('configured') ? device.meta.configured: 'none'} -  ${cfgkey} (query took ${Date.now()- t} ms)`);
         return result;
     }
 
@@ -86,10 +86,10 @@ class DeviceConfigure extends BaseExtension {
             for (const device of await this.zigbee.getClientIterator()) {
                 const mappedDevice = await zigbeeHerdsmanConverters.findByDevice(device);
                 if (this.shouldConfigure(device, mappedDevice)) {
-                    this.info(`DeviceConfigure ${device.ieeeAddr} ${mappedDevice ? mappedDevice.model : device.modelID} needed - Device added to Configuration Queue`);
+                    this.info(`DeviceConfigure '${this.devLabel(device.ieeeAddr)}' needed - Device added to Configuration Queue`);
                     this.PushDeviceToQueue(device, mappedDevice);
                 } else {
-                    this.debug(`DeviceConfigure ${device.ieeeAddr} ${mappedDevice ? mappedDevice.model : device.modelID} not needed`);
+                    this.debug(`DeviceConfigure '${this.devLabel(device.ieeeAddr)}' not needed`);
                 }
             }
         } catch (error) {
@@ -107,7 +107,7 @@ class DeviceConfigure extends BaseExtension {
                 this.info(`checking configure on message :  next attempt in ${30000 - (Date.now() - com.timestamp)} seconds`);
                 if (Date.now() - com.timestamp > 30000 && !this.configuring.has(device.ieeeAddr)) {
                     com.timestamp = Date.now();
-                    this.info('Configure on Message for ' + device.ieeeAddr);
+                    this.info('Configure on Message for ' + "'" + this.devLabel(device.ieeeAddr) + "'");
                     this.doConfigure(device, mappedDevice);
                 }
                 return;
@@ -155,23 +155,23 @@ class DeviceConfigure extends BaseExtension {
                     await this.doConfigure(device, mappedDevice)
                 } catch (error) {
                     this.sendError(error);
-                    this.warn(`DeviceConfigure failed ${device.ieeeAddr} ${mappedDevice.model}`);
+                    this.warn(`DeviceConfigure failed '${this.devLabel(device.ieeeAddr)}'`);
                 }
             }
         } catch (error) {
             this.sendError(error);
-            this.error(`Failed to DeviceConfigure.configure ${device.ieeeAddr} ${mappedDevice.model}: ${error && error.message ? error.message : 'no error message'})`);
+            this.error(`Failed to DeviceConfigure.configure '${this.devLabel(device.ieeeAddr)}': ${error && error.message ? error.message : 'no error message'})`);
         }
     }
 
     async tryInterview(device) {
         if (device) try {
             this.retriedUnsupportedClusters.add(device.ieeeAddr);
-            this.info(`manual Interview for ${device.ieeeAddr} ${device.modelID}`);
+            this.info(`manual Interview for '${this.devLabel(device.ieeeAddr)}'`);
             await device.interview(true);
-            this.info(`interview for ${device.ieeeAddr} ${device.modelID} complete`);
+            this.info(`interview for '${this.devLabel(device.ieeeAddr)}' complete`);
         } catch (error) {
-            return {error:`Interview failed ${device.ieeeAddr} ${device.modelID}, (${error.message})`}
+            return {error:`Interview failed '${this.devLabel(device.ieeeAddr)}', (${error.message})`}
         }
         return {}
     }
@@ -181,11 +181,11 @@ class DeviceConfigure extends BaseExtension {
         const cfgKey = mappedDevice?.version ?? '0.0.0';
         try {
             if (mappedDevice) {
-                if (mappedDevice.configure === undefined) return `No configure available for ${device.ieeeAddr} ${mappedDevice.model}.`;
+                if (mappedDevice.configure === undefined) return `No configure available for '${this.devLabel(device.ieeeAddr)}'.`;
                 if (cfgKey != device.meta.configured)
-                    this.info(`Configuring ${device.ieeeAddr} (${mappedDevice.model}) ${device.meta.configured ? 'from V'+ device.meta.configured : ''} to V${cfgKey}`);
+                    this.info(`Configuring '${this.devLabel(device.ieeeAddr)}' ${device.meta.configured ? 'from V'+ device.meta.configured : ''} to V${cfgKey}`);
                 else
-                    this.info(`Reconfiguring ${device.ieeeAddr} (${mappedDevice.model}) with V${cfgKey}`);
+                    this.info(`Reconfiguring '${this.devLabel(device.ieeeAddr)}' with V${cfgKey}`);
                 this.configuring.add(device.ieeeAddr);
                 if (typeof mappedDevice.configure === 'function') await mappedDevice.configure(device, coordinatorEndpoint, mappedDevice);
                 else {
@@ -197,7 +197,7 @@ class DeviceConfigure extends BaseExtension {
                 this.configuring.delete(device.ieeeAddr);
                 delete this.configureOnMessageAttempts[device.ieeeAddr];
                 device.save();
-                this.info(`DeviceConfigure to V${device.meta.configured} for ${device.ieeeAddr} (${mappedDevice.model}) successful.`);
+                this.info(`DeviceConfigure to V${device.meta.configured} for '${this.devLabel(device.ieeeAddr)}' successful.`);
                 return '';
             }
         } catch (error) {
@@ -210,7 +210,7 @@ class DeviceConfigure extends BaseExtension {
                 this.configuring.delete(device.ieeeAddr);
                 delete this.configureOnMessageAttempts[device.ieeeAddr];
                 device.save();
-                this.info(`DeviceConfigure to V${device.meta.configured} for ${device.ieeeAddr} (${mappedDevice.model}) successful.`);
+                this.info(`DeviceConfigure to V${device.meta.configured} for '${this.devLabel(device.ieeeAddr)}' successful.`);
                 return '';
             }
             // https://github.com/Koenkk/zigbee2mqtt/issues/14857
@@ -224,22 +224,22 @@ class DeviceConfigure extends BaseExtension {
                     com.timestamp = Date.now();
                     if ( com.count < 0) {
                         delete this.configureOnMessageAttempts[device.ieeeAddr];
-                        this.info(`Configure on message abandoned for ${device.ieeeAddr} ${mappedDevice.model} after failing ${com.attempts} times.`)
+                        this.info(`Configure on message abandoned for '${this.devLabel(device.ieeeAddr)}' after failing ${com.attempts} times.`)
                     }
-                    else this.info(`Timeout trying to configure ${device.ieeeAddr} ${mappedDevice.model} (${com.count}).`)
+                    else this.info(`Timeout trying to configure '${this.devLabel(device.ieeeAddr)}' (${com.count}).`)
                 }
                 else {
-                    this.info(`Timeout trying to configure ${device.ieeeAddr} ${mappedDevice.model} (starting CoM).`)
+                    this.info(`Timeout trying to configure '${this.devLabel(device.ieeeAddr)}' (starting CoM).`)
                     this.configureOnMessageAttempts[device.ieeeAddr] = {
                         count: 5,
                         timestamp: 0,
                         attempts: 0,
                     };
                 }
-                return `Configuration timed out ${device.ieeeAddr} ${device.modelID}. The device did not repond in time to the configuration request. Another attempt will be made when the device is awake.`;
+                return `Configuration timed out '${this.devLabel(device.ieeeAddr)}'. The device did not repond in time to the configuration request. Another attempt will be made when the device is awake.`;
             } else {
                 this.sendError(error);
-                const msg = `${device.ieeeAddr} ${device.modelID} Failed to configure. --> ${errmsg}${errmsg.includes(`UNSUPPORTED_CLUSTER`) ? ' - You may need to restart the adapter and reconfigure the device for this device to work properly' : ''}`
+                const msg = `'${this.devLabel(device.ieeeAddr)}' Failed to configure. --> ${errmsg}${errmsg.includes(`UNSUPPORTED_CLUSTER`) ? ' - You may need to restart the adapter and reconfigure the device for this device to work properly' : ''}`
                 this.warn(msg);
                 return msg;
 

--- a/lib/zbDeviceEvent.js
+++ b/lib/zbDeviceEvent.js
@@ -33,7 +33,7 @@ class DeviceEvent extends BaseExtension {
     }
 
     async deviceExposeChanged(device, mapped) {
-        this.warn(`deviceExposesChanged called with ${JSON.stringify(device.ieeeAddr)} / ${JSON.stringify(mapped.model)}`);
+        this.warn(`deviceExposesChanged called with '${this.devLabel(device.ieeeAddr)}' / ${JSON.stringify(mapped.model)}`);
     }
 
     async callOnEvent(device, type, data, mappedDevice) {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -12,6 +12,7 @@ const DeviceConfigureExt = require('./zbDeviceConfigure');
 const DeviceEventExt = require('./zbDeviceEvent');
 const DelayedActionExt = require('./zbDelayedAction');
 const utils = require('./utils');
+const { devLabel } = require('./deviceLabel');
 
 const { access, constants } =require('node:fs/promises');
 
@@ -306,7 +307,7 @@ class ZigbeeController extends EventEmitter {
                 // get the model description for the known devices
                 const entity = await this.resolveEntity(device);
                 if (!entity) {
-                    this.debug('failed to resolve Entity for ' + device.ieeeAddr);
+                    this.debug('failed to resolve Entity for ' + "'" + this.devLabel(device.ieeeAddr) + "'");
                     continue;
                 }
 
@@ -322,7 +323,7 @@ class ZigbeeController extends EventEmitter {
                 if (entity.mapped) {
                     this.emit('new', entity);
                 }
-                const msg = (entity.device.ieeeAddr +
+                const msg = ("'" + this.devLabel(entity.device.ieeeAddr) + "'" +
                     ` (addr ${entity.device.networkAddress}): ` +
                     (entity.mapped ? `${entity.mapped.model} - ${entity.mapped.vendor} ${entity.mapped.description} ` : `Unsupported (model ${entity.device.modelID})`) +
                     `(${entity.device.type})`);
@@ -497,7 +498,7 @@ class ZigbeeController extends EventEmitter {
 
             }
         } catch (error) {
-            this.error(`the command ${command} failed for ${devId}: ${error?.message}`);
+            this.error(`the command ${command} failed for '${this.devLabel(devId)}': ${error?.message}`);
         }
         return false;
     }
@@ -505,7 +506,7 @@ class ZigbeeController extends EventEmitter {
 
     async reconfigure(devId) {
         if (!this.herdsmanStarted) return  {error: 'No active connection to Zigbee Hardware!'};
-        this.debug(`Reconfigure ${devId}`);
+        this.debug(`Reconfigure '${this.devLabel(devId)}'`);
         const entity = await this.resolveEntity(devId);
         if (entity) {
             try {
@@ -528,9 +529,9 @@ class ZigbeeController extends EventEmitter {
     {
         const entity = await this.resolveEntity(devId);
         if (entity) try {
-            this.info(`manual Interview for ${entity.device.ieeeAddr} ${entity.device.modelID}`);
+            this.info(`manual Interview for '${this.devLabel(entity.device.ieeeAddr)}'`);
             await entity.device.interview(true);
-            this.info(`interview for ${entity.device.ieeeAddr} ${entity.device.modelID} complete`);
+            this.info(`interview for '${this.devLabel(entity.device.ieeeAddr)}' complete`);
         } catch (error) {
             return {error:`Interview failed ${entity.device.ieeeAddr} ${entity.device.modelID}, (${error.message})`}
         }
@@ -1036,7 +1037,7 @@ class ZigbeeController extends EventEmitter {
                     message = error.message;
 
             }
-            const msg = `Failed to remove ${deviceID ? 'device ' + deviceID : 'unspecified device'}: ${message}`;
+            const msg = `Failed to remove ${deviceID ? 'device ' + "'" + this.devLabel(deviceID) + "'" : 'unspecified device'}: ${message}`;
             return { status:false, error:msg};
         }
         return {status:true};
@@ -1061,7 +1062,7 @@ class ZigbeeController extends EventEmitter {
             const entity = await this.resolveEntity(message.device || message.ieeeAddr);
             if (entity) {
                 if ((this.localConfig.getDeviceOption(entity.device.ieeeAddr, entity.model.modelID, false) ?? {}).ignore_device_delete) {
-                    this.warn(`Ignoring device_leave message from ${message.ieeeAddr} (${entity.model.modelID})`);
+                    this.warn(`Ignoring device_leave message from '${this.devLabel(message.ieeeAddr)}' (${entity.model.modelID})`);
                     return;
                 }
             }
@@ -1069,16 +1070,24 @@ class ZigbeeController extends EventEmitter {
         this.herdsmanListeners.forEach(fn => fn(message));
     }
 
+    // Log label for a device: user-assigned name if set, otherwise the id/address.
+    devLabel(idOrIeee, model) {
+        return devLabel(this.adapter, idOrIeee, model);
+    }
+
     async handleDeviceLeave(message) {
         try {
             if (this.debugActive) this.debug('handleDeviceLeave', message);
             const entity = await this.resolveEntity(message.device || message.ieeeAddr);
             const friendlyName = entity ? entity.name : message.ieeeAddr;
+            const displayName = entity
+                ? utils.deviceDisplayName(entity.device?.ieeeAddr ?? message.ieeeAddr, this.adapter.stController.verifyDeviceName(entity.id, entity.mapped?.model, null))
+                : message.ieeeAddr;
             if (this.adapter.stController.checkDebugDevice(friendlyName)) {
-                this.emit('device_debug', {ID: Date.now(), data: {flag:'dl', states:[{id: '--', value:'--', payload:message}], IO:true},message:`Device '${friendlyName}' has left the network`});
+                this.emit('device_debug', {ID: Date.now(), data: {flag:'dl', states:[{id: '--', value:'--', payload:message}], IO:true},message:`Device '${displayName}' has left the network`});
             }
             else
-                this.warn(`Device '${friendlyName}' left the network`);
+                this.warn(`Device '${displayName}' left the network`);
             this.emit('leave', message.ieeeAddr, entity?.mapped?.model);
             // Call extensions
             this.callExtensionMethod(
@@ -1095,13 +1104,16 @@ class ZigbeeController extends EventEmitter {
         if (this.debugActive) this.debug('handleDeviceAnnounce', message);
         const entity = await this.resolveEntity(message.device || message.ieeeAddr);
         const friendlyName = entity ? entity.name : message.ieeeAddr ? message.ieeeAddr : message.device && message.device.ieeeAddr ? message.device.ieeeAddr : 'without data';
+        const displayName = entity
+            ? utils.deviceDisplayName(entity.device?.ieeeAddr ?? message.ieeeAddr, this.adapter.stController.verifyDeviceName(entity.id, entity.mapped?.model, null))
+            : friendlyName;
 
-        this.emit('pairing', `Device '${friendlyName}' announced itself`);
+        this.emit('pairing', `Device '${displayName}' announced itself`);
         if (!entity) return;
         this.emit('announce', friendlyName, entity?.mapped?.model)
 
         if (this.adapter.stController.checkDebugDevice(friendlyName)) {
-            this.emit('device_debug', {ID: Date.now(), data: {flag:'da', states:[{id: '--', value:'--', payload:message}] , IO:true} ,message:`Device '${friendlyName}' announced itself`});
+            this.emit('device_debug', {ID: Date.now(), data: {flag:'da', states:[{id: '--', value:'--', payload:message}] , IO:true} ,message:`Device '${displayName}' announced itself`});
         }
 
         if (this.herdsman.getPermitJoin() && (entity?.device?.interviewState != 'SUCCESSFUL')) {
@@ -1112,9 +1124,9 @@ class ZigbeeController extends EventEmitter {
 
 
         if (this.warnOnDeviceAnnouncement) {
-            this.warn(`Device '${friendlyName}' announced itself${this.readAtAnnounce ? ', trying to read its status' : ''}`);
+            this.warn(`Device '${displayName}' announced itself${this.readAtAnnounce ? ', trying to read its status' : ''}`);
         } else {
-            this.info(`Device '${friendlyName}' announced itself${this.readAtAnnounce ? ', trying to read its status' : ''}`);
+            this.info(`Device '${displayName}' announced itself${this.readAtAnnounce ? ', trying to read its status' : ''}`);
         }
 
         /*
@@ -1157,13 +1169,13 @@ class ZigbeeController extends EventEmitter {
         // safeguard: We do not allow to start an interview if the network is not opened
         /*
         if (message.status === 'started' && !this.herdsman.getPermitJoin()) {
-            this.warn(`Ignored interview for '${message.ieeeAddr}' because the network is closed`);
+            this.warn(`Ignored interview for '${this.devLabel(message.ieeeAddr)}' because the network is closed`);
             return;
         }
         */
         try {
             const entity = await this.resolveEntity(message.device || message.ieeeAddr);
-            const friendlyName = entity.name;
+            const friendlyName = this.devLabel(entity.device.ieeeAddr);
             const onZigbeeEventparameters = [message, entity.mapped ? entity.mapped: null];
 
             switch (message.status) {
@@ -1270,7 +1282,7 @@ class ZigbeeController extends EventEmitter {
                 }
                 const entity = await this.resolveEntity(device, 0) ?? { name:'unresolved device', device:device };
                 if (entity.name === 'unresolved device' && this.debugActive) {
-                    this.debug('resolve Entity failed for ' + device.ieeeAddr);
+                    this.debug('resolve Entity failed for ' + "'" + this.devLabel(device.ieeeAddr) + "'");
                 }
 
                 let attemptRouting = true;
@@ -1380,7 +1392,7 @@ class ZigbeeController extends EventEmitter {
             return;
         }
 
-        if (this.debugActive) this.debug(`Zigbee publish to '${deviceID}', ${cid} - cmd ${cmd} - payload ${JSON.stringify(zclData)} - cfg ${JSON.stringify(cfg)} - endpoint ${ep}`);
+        if (this.debugActive) this.debug(`Zigbee publish to '${this.devLabel(deviceID)}', ${cid} - cmd ${cmd} - payload ${JSON.stringify(zclData)} - cfg ${JSON.stringify(cfg)} - endpoint ${ep}`);
 
         if (cfg == null) {
             cfg = {};
@@ -1464,24 +1476,24 @@ class ZigbeeController extends EventEmitter {
         if (has_elevated_debug)
         {
             const stateNames = stateList.map((state) => state.stateDesc.id);
-            const message = `Publishing to ${deviceId} of model ${model} with ${stateNames.join(', ')}`;
+            const message = `Publishing to '${this.devLabel(deviceId)}' of model ${model} with ${stateNames.join(', ')}`;
             this.emit('device_debug', { ID:debugID, data: { ID: deviceId, flag: '03', IO:false }, message: message});
         }
         else
-            if (this.debugActive) this.debug(`main publishFromState : ${deviceId} ${model} ${safeJsonStringify(stateList)}`);
+            if (this.debugActive) this.debug(`main publishFromState : '${this.devLabel(deviceId)}' ${model} ${safeJsonStringify(stateList)}`);
         if (model === 'group') {
             isGroup = true;
             deviceId = parseInt(deviceId);
         }
         try {
             const entity = await this.resolveEntity(deviceId);
-            if (this.debugActive) this.debug(`entity: ${deviceId} ${model} ${safeJsonStringify(utils.entityData(entity, true))}`);
+            if (this.debugActive) this.debug(`entity: '${this.devLabel(deviceId)}' ${model} ${safeJsonStringify(utils.entityData(entity, true))}`);
             const mappedModel = entity ? entity.mapped : undefined;
 
             if (!mappedModel) {
                 if (this.debugActive) this.debug(`No mapped model for ${model}`);
                 if (has_elevated_debug) {
-                    const message=`No mapped model ${deviceId} (model ${model})`;
+                    const message=`No mapped model '${this.devLabel(deviceId)}' (model ${model})`;
                     this.emit('device_debug', { ID:debugID, data: { error: 'NOMODEL' , IO:false }, message: message});
                 }
                 return;
@@ -1509,11 +1521,11 @@ class ZigbeeController extends EventEmitter {
                 let msg_counter = 0;
                 if (stateDesc.isOption) {
                     if (has_elevated_debug) {
-                        const message = `No converter needed on option state for ${deviceId} of type ${model}`;
+                        const message = `No converter needed on option state for '${this.devLabel(deviceId)}' of type ${model}`;
                         this.emit('device_debug', { ID:debugID, data: { flag: `SUCCESS` , IO:false }, message:message});
                     }
                     else
-                        if (this.debugActive) this.debug(`No converter needed on option state for ${deviceId} of type ${model}`);
+                        if (this.debugActive) this.debug(`No converter needed on option state for '${this.devLabel(deviceId)}' of type ${model}`);
 
                     continue;
                 }
@@ -1538,22 +1550,22 @@ class ZigbeeController extends EventEmitter {
                             }
                             converter = c;
                             if (has_elevated_debug) {
-                                const message = `Setting converter to keyless converter for ${deviceId} of type ${model}`;
+                                const message = `Setting converter to keyless converter for '${this.devLabel(deviceId)}' of type ${model}`;
                                 this.emit('device_debug', { ID:debugID, data: { flag: `s4.${msg_counter}` , IO:false }, message:message});
                             }
                             else
-                                if (this.debugActive) this.debug(`Setting converter to keyless converter for ${deviceId} of type ${model}`);
+                                if (this.debugActive) this.debug(`Setting converter to keyless converter for '${this.devLabel(deviceId)}' of type ${model}`);
                             msg_counter++;
                         }
                         else
                         {
                             if (has_elevated_debug)
                             {
-                                const message = `ignoring keyless converter for ${deviceId} of type ${model}`;
+                                const message = `ignoring keyless converter for '${this.devLabel(deviceId)}' of type ${model}`;
                                 this.emit('device_debug', { ID:debugID, data: { flag: `i4.${msg_counter}` , IO:false} , message:message});
                             }
                             else
-                                if (this.debugActive) this.debug(`ignoring keyless converter for ${deviceId} of type ${model}`);
+                                if (this.debugActive) this.debug(`ignoring keyless converter for '${this.devLabel(deviceId)}' of type ${model}`);
                             msg_counter++;
                         }
                         continue;
@@ -1605,7 +1617,7 @@ class ZigbeeController extends EventEmitter {
 
                 const epName = stateDesc.epname !== undefined ? stateDesc.epname : (stateDesc.prop || stateDesc.id);
                 const key = stateDesc.setattr || stateDesc.prop || stateDesc.id;
-                const message = `convert ${key} with value ${safeJsonStringify(preparedValue)} and options ${safeJsonStringify(preparedOptions)} for device ${deviceId} ${stateDesc.epname ? `with Endpoint ${epName}` : 'without Endpoint'}`;
+                const message = `convert ${key} with value ${safeJsonStringify(preparedValue)} and options ${safeJsonStringify(preparedOptions)} for device '${this.devLabel(deviceId)}' ${stateDesc.epname ? `with Endpoint ${epName}` : 'without Endpoint'}`;
                 if (has_elevated_debug) {
                     this.emit('device_debug', { ID:debugID, data: { flag: '04', payload: {key:key, ep: stateDesc.epname, value:preparedValue, options:preparedOptions}, IO:false }, message:message});
                 }
@@ -1702,7 +1714,7 @@ class ZigbeeController extends EventEmitter {
                         const fromObject = false;
                         const preparedObject = null;
                         //const { result, fromObject } = await this.getConverterValue(converter, target, key, preparedValue, preparedObject, meta);
-                        const message = `convert result ${safeJsonStringify(result)} for device ${deviceId}`;
+                        const message = `convert result ${safeJsonStringify(result)} for device '${this.devLabel(deviceId)}'`;
                         if (isGroup)
                             this.emit('published', deviceId, model, stateModel, stateList, options, debugID, has_elevated_debug );
                         if (has_elevated_debug) {
@@ -1720,7 +1732,7 @@ class ZigbeeController extends EventEmitter {
                         else {
                             if (has_elevated_debug) {
                                 const stringvalue = fromObject ? safeJsonStringify(preparedObject) : typeof preparedValue == 'object' ? safeJsonStringify(preparedValue) : preparedValue;
-                                const message = `Convert does not return a result result for ${key} with ${stringvalue} on device ${deviceId}.`;
+                                const message = `Convert does not return a result result for ${key} with ${stringvalue} on device '${this.devLabel(deviceId)}'.`;
                                 this.emit('device_debug', { ID:debugID, data: { flag: `0${OCnt++}` , IO:false }, message:message});
                             }
                         }
@@ -1736,7 +1748,7 @@ class ZigbeeController extends EventEmitter {
                                         try {
                                             await c.convertGet(target, key, {device:entity.device}) }
                                         catch (error) {
-                                            this.warn(`error reading ${key} from ${deviceId} : ${error?.message}`);
+                                            this.warn(`error reading ${key} from '${this.devLabel(deviceId)}' : ${error?.message}`);
                                         }
                                     }, tt ? tt * 1000+250 : 1000);
                                 }
@@ -1744,17 +1756,17 @@ class ZigbeeController extends EventEmitter {
                         }
                     } catch (error) {
                         if (has_elevated_debug) {
-                            const message = `caught error ${error?.message ?? 'no reason given'} when setting value for device ${deviceId} (${error?.stack ?? ''}).`;
+                            const message = `caught error ${error?.message ?? 'no reason given'} when setting value for device '${this.devLabel(deviceId)}' (${error?.stack ?? ''}).`;
                             this.emit('device_debug', { ID:debugID, data: { error: `EXSET${error.code == 25 ? retry : ''}` , IO:false },message:message});
                         }
                         if (error.code === 25 && retry > 0) {
-                            this.warn(`Error ${error.code} on send command to ${deviceId}. (${retry} tries left.), Error: ${error.message}`);
+                            this.warn(`Error ${error.code} on send command to '${this.devLabel(deviceId)}'. (${retry} tries left.), Error: ${error.message}`);
                             retry--;
                             await new Promise(resolve => setTimeout(resolve, 200));
                         }
                         else {
                             retry = 0;
-                            this.adapter.filterError(`Error ${error.code} on send command to ${deviceId}.` +
+                            this.adapter.filterError(`Error ${error.code} on send command to '${this.devLabel(deviceId)}'.` +
                             ` Error: ${error.message}`, `Send command to ${deviceId} failed with`, error);
                         }
                     }
@@ -1765,7 +1777,7 @@ class ZigbeeController extends EventEmitter {
 
 
         } catch (err) {
-            const message = `No entity for ${deviceId} : ${err && err.message ? err.message : 'no error message'}`;
+            const message = `No entity for '${this.devLabel(deviceId)}' : ${err && err.message ? err.message : 'no error message'}`;
             if (has_elevated_debug) {
                 this.emit('device_debug', { ID:debugID, data: { error: 'EXPUB' , IO:false }, message:message});
             }
@@ -1868,8 +1880,8 @@ class ZigbeeController extends EventEmitter {
                     }
                     return {success: true};
                 } catch (error) {
-                    this.error(`Error ${error.code} on send command to ${payload.device}.` + ` Error: ${error.stack} ` + `Send command to ${payload.device} failed with ` + error);
-                    this.adapter.filterError(`Error ${error.code} on send command to ${payload.device}.` + ` Error: ${error.stack}`, `Send command to ${payload.device} failed with`, error);
+                    this.error(`Error ${error.code} on send command to '${this.devLabel(payload.device)}'.` + ` Error: ${error.stack} ` + `Send command to '${this.devLabel(payload.device)}' failed with ` + error);
+                    this.adapter.filterError(`Error ${error.code} on send command to '${this.devLabel(payload.device)}'.` + ` Error: ${error.stack}`, `Send command to '${this.devLabel(payload.device)}' failed with`, error);
                     return {success: false, error};
                 }
             } catch (e) {
@@ -1882,17 +1894,17 @@ class ZigbeeController extends EventEmitter {
 
     async doDeviceQuery(deviceId, debugID, elevated, keyList) {
         const entity = await this.resolveEntity(deviceId);
-        if (this.debugActive) this.debug(`doDeviceQuery: resolveEntity for entity: ${deviceId} is ${safeJsonStringify(utils.entityData(entity))}`);
+        if (this.debugActive) this.debug(`doDeviceQuery: resolveEntity for entity: '${this.devLabel(deviceId)}' is ${safeJsonStringify(utils.entityData(entity))}`);
         const mappedModel = entity ? entity.mapped : undefined;
         if (mappedModel) {
             const epmap = mappedModel.endpoint ? mappedModel.endpoint(entity.device) : [];
             if (elevated) {
-                const message  = `Device query for '${entity.device.ieeeAddr}' triggered`;
+                const message  = `Device query for '${this.devLabel(entity.device.ieeeAddr)}' triggered`;
                 this.emit('device_debug', { ID:debugID, data: { flag: 'qs' ,states:[{id:'device_query', value:true, payload:'device_query'}], IO:false }, message:message});
             }
             else
-                if (this.debugActive) this.debug(`Device query for '${entity.device.ieeeAddr}' started`);
-                else this.info(`Device query for '${entity.device.ieeeAddr}' started`);
+                if (this.debugActive) this.debug(`Device query for '${this.devLabel(entity.device.ieeeAddr)}' started`);
+                else this.info(`Device query for '${this.devLabel(entity.device.ieeeAddr)}' started`);
 
             const payload = { key:'device_query', read_states:[], unread_states:[] };
             let cCount = 0;
@@ -1916,12 +1928,12 @@ class ZigbeeController extends EventEmitter {
                                     await converter.convertGet(source, k, {device:entity.device});
                                     payload.read_states.push(`${cCount}.${k}`);
                                     if (elevated) {
-                                        const message = `read for state ${k} of '${converter.key.join(',')}' of '${entity.device.ieeeAddr}/${source.ID}' after device query`;
+                                        const message = `read for state ${k} of '${converter.key.join(',')}' of '${this.devLabel(entity.device.ieeeAddr)}/${source.ID}' after device query`;
                                         this.warn(`ELEVATED O02.1 ${message}`);
                                         this.emit('device_debug', { ID:debugID, data: { flag: '03', IO:false }, message:message });
                                     }
                                     else
-                                        this.debug(`read for state${converter.key.length ? '' : 's'} '${converter.key.join(',')}' of '${entity.device.ieeeAddr}/${source.ID}' after device query`);
+                                        this.debug(`read for state${converter.key.length ? '' : 's'} '${converter.key.join(',')}' of '${this.devLabel(entity.device.ieeeAddr)}/${source.ID}' after device query`);
                                 } catch (error) {
                                     payload.unread_states.push(`${cCount}.${k}`);
                                     if (elevated) {
@@ -1936,17 +1948,17 @@ class ZigbeeController extends EventEmitter {
                 }
             }
             if (elevated) {
-                const message = `ELEVATED O07: Device query for '${entity.device.ieeeAddr}}' complete`;
+                const message = `ELEVATED O07: Device query for '${this.devLabel(entity.device.ieeeAddr)}}' complete`;
                 this.emit('device_debug', { ID:debugID, data: { flag: 'qe' , IO:false , payload }, message:message});
             }
             else
-                this.info(`Device query for '${entity.device.ieeeAddr}' complete`);
+                this.info(`Device query for '${this.devLabel(entity.device.ieeeAddr)}' complete`);
         }
     }
 
     async deviceQuery(deviceId, debugID, elevated, callback) {
         if (this.deviceQueryActive.includes (deviceId)) {
-            this.info(`Device query for ${deviceId} is still active.`);
+            this.info(`Device query for '${this.devLabel(deviceId)}' is still active.`);
             return;
         }
         this.deviceQueryActive.push(deviceId);
@@ -1965,7 +1977,7 @@ class ZigbeeController extends EventEmitter {
 
     async addDevToGroup(devId, groupId, epid) {
         try {
-            if (this.debugActive) this.debug(`called addDevToGroup with ${devId}, ${groupId}, ${epid}`);
+            if (this.debugActive) this.debug(`called addDevToGroup with '${this.devLabel(devId)}', ${groupId}, ${epid}`);
             const entity = await this.resolveEntity(devId);
             const group = await this.resolveEntity(groupId);
             if (this.debugActive) this.debug(`addDevFromGroup - entity: ${utils.getEntityInfo(entity)}`);
@@ -1978,18 +1990,18 @@ class ZigbeeController extends EventEmitter {
             if (this.debugActive) this.debug(`addDevToGroup ${groupId} with ${memberIDs.length} members ${safeJsonStringify(memberIDs)}`);
             if (epid != undefined) {
                 for (const ep of entity.endpoints) {
-                    if (this.debugActive) this.debug(`checking ep ${ep.ID} of ${devId} (${epid})`);
+                    if (this.debugActive) this.debug(`checking ep ${ep.ID} of '${this.devLabel(devId)}' (${epid})`);
                     if (ep.ID == epid) {
                         if (ep.inputClusters.includes(4) || ep.outputClusters.includes(4)) {
                             if (this.debugActive) this.debug(`adding endpoint ${ep.ID} (${epid}) to group ${groupId}`);
                             await (ep.addToGroup(group.mapped));
                         }
-                        else this.error(`cluster genGroups not supported for endpoint ${epid} of ${devId}`);
+                        else this.error(`cluster genGroups not supported for endpoint ${epid} of '${this.devLabel(devId)}'`);
                     }
                 }
             } else {
                 if (entity.endpoint.inputClusters.includes(4)) {
-                    this.info(`adding endpoint ${entity.endpoint.ID} of ${devId} to group`);
+                    this.info(`adding endpoint ${entity.endpoint.ID} of '${this.devLabel(devId)}' to group`);
                     await entity.endpoint.addToGroup(group.mapped);
                 } else {
                     let added = false;
@@ -2007,14 +2019,14 @@ class ZigbeeController extends EventEmitter {
             }
         } catch (error) {
             this.sendError(error);
-            this.error(`Exception when trying to Add ${devId}  to group ${groupId}`, error);
+            this.error(`Exception when trying to Add '${this.devLabel(devId)}'  to group ${groupId}`, error);
             return {error: `Failed to add ${devId}  to group ${groupId}: ${JSON.stringify(error)}`};
         }
         return {};
     }
 
     async removeDevFromGroup(devId, groupId, epid) {
-        if (this.debugActive) this.debug(`removeDevFromGroup with ${devId}, ${groupId}, ${epid}`);
+        if (this.debugActive) this.debug(`removeDevFromGroup with '${this.devLabel(devId)}', ${groupId}, ${epid}`);
         let entity; // needed to have access to entity outside in the catch path.
         try {
             entity = await this.resolveEntity(devId);
@@ -2023,26 +2035,26 @@ class ZigbeeController extends EventEmitter {
             if (group) {
                 if (epid != undefined) {
                     for (const ep of entity.endpoints) {
-                        if (this.debugActive) this.debug(`checking ep ${ep.ID} of ${devId} (${epid})`);
+                        if (this.debugActive) this.debug(`checking ep ${ep.ID} of '${this.devLabel(devId)}' (${epid})`);
                         if (ep.ID == epid && (ep.inputClusters.includes(4) || ep.outputClusters.includes(4))) {
                             await ep.removeFromGroup(group);
-                            this.info(`removing endpoint ${ep.ID} of ${devId} from group ${groupId}`);
+                            this.info(`removing endpoint ${ep.ID} of '${this.devLabel(devId)}' from group ${groupId}`);
                         }
                     }
                 } else {
                     await entity.endpoint.removeFromGroup(group);
-                    this.info(`removing endpoint ${entity.endpoint.ID} of ${devId} from group ${groupId}`);
+                    this.info(`removing endpoint ${entity.endpoint.ID} of '${this.devLabel(devId)}' from group ${groupId}`);
                 }
             }
             else {
-                const msg = `Unable to resolve group ${groupId} when removing ${devId} (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group`
+                const msg = `Unable to resolve group ${groupId} when removing '${this.devLabel(devId)}' (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group`
                 this.error(msg);
                 return {error: msg};
             }
 
         } catch (error) {
             this.sendError(error);
-            const msg = `Exception when trying remove ${devId} (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group ${devId}`
+            const msg = `Exception when trying remove '${this.devLabel(devId)}' (ep ${epid ? epid : (entity ? entity.endpoint.ID : '')}) from group '${this.devLabel(devId)}'`
             this.error(msg, error);
             return {error: msg};
         }
@@ -2060,7 +2072,7 @@ class ZigbeeController extends EventEmitter {
             }
         } catch (error) {
             this.sendError(error);
-            this.error(`Exception when trying remove ${devId} from all groups`, error);
+            this.error(`Exception when trying remove '${this.devLabel(devId)}' from all groups`, error);
             return {error: `Failed to remove dev ${devId} from all groups: ${error}`};
         }
         return {};

--- a/main.js
+++ b/main.js
@@ -34,6 +34,7 @@ const OtaPlugin = require('./lib/ota');
 const BackupPlugin = require('./lib/backup');
 // libraries
 const utils = require('./lib/utils');
+const { devLabel } = require('./lib/deviceLabel');
 const dmZigbee  = require('./lib/devicemgmt.js');
 const DeviceDebug = require('./lib/DeviceDebug');
 const localConfig = require('./lib/localConfig');
@@ -763,17 +764,17 @@ class Zigbee extends adapterCore.Adapter {
         const model = (entity.mapped) ? entity.mapped.model : device.modelID;
         this.log.debug(`New device event: ${safeJsonStringify(utils.entityData(entity))}`);
         if (!entity.mapped && !entity.device.interviewing) {
-            const msg = `New device: '${device.ieeeAddr}' does not have a known model. please provide an external converter for '${device.modelID}'.`;
+            const msg = `New device: '${devLabel(this, device.ieeeAddr)}' does not have a known model. please provide an external converter for '${device.modelID}'.`;
             this.log.warn(msg);
             this.logToPairing(msg, true);
         }
         await this.stController.AddModelFromHerdsman(entity.device, model)
         if (device) {
             this.getObjectAsync(utils.zbIdorIeeetoAdId(this, device.ieeeAddr, false), (_err, obj) => {
-                if (!obj) this.logToPairing(`New device joined '${device.ieeeAddr}' model ${model}`, true);
+                if (!obj) this.logToPairing(`New device joined '${devLabel(this, device.ieeeAddr)}' model ${model}`, true);
             });
             const model = (entity.mapped) ? entity.mapped.model : entity.device.modelID;
-            if (this.debugActive) this.log.debug(`new device ${device.ieeeAddr} ${device.networkAddress} ${model} `);
+            if (this.debugActive) this.log.debug(`new device '${devLabel(this, device.ieeeAddr)}' ${device.networkAddress} ${model} `);
             await this.stController.updateDev(utils.zbIdorIeeetoAdId(this, device.ieeeAddr, false), entity.name, model);
             await this.stController.syncDevStates(device, model);
         }
@@ -782,10 +783,10 @@ class Zigbee extends adapterCore.Adapter {
     /*
 
     leaveDevice(ieeeAddr) {
-        if (this.debugActive) this.log.debug(`Leave device event: ${ieeeAddr}`);
+        if (this.debugActive) this.log.debug(`Leave device event: '${devLabel(this, ieeeAddr)}'`);
         if (ieeeAddr) {
             const devId = zbIdorIeeetoAdId(this, ieeeAddr, false);
-            if (this.debugActive) this.log.debug(`Delete device ${devId} from iobroker.`);
+            if (this.debugActive) this.log.debug(`Delete device '${devLabel(this, devId)}' from iobroker.`);
             this.stController.deleteObj(devId);
         }
     }
@@ -1096,7 +1097,7 @@ class Zigbee extends adapterCore.Adapter {
                 return rv;
             }
             const dev = entity ? entity.device || {} : {}
-            const msg = entity ? `device ${entity.name} (${dev.ieeeAddr}, NWK ${dev.networkAddres}, ID: ${dev.ID})` : 'undefined device';
+            const msg = entity ? `device '${devLabel(this, dev.ieeeAddr)}' (${dev.ieeeAddr}, NWK ${dev.networkAddres}, ID: ${dev.ID})` : 'undefined device';
             this.log.warn(`Error ${error && error.message ? error.message + ' ' : ''}building device info for ${msg}`);
         }
         return rv;


### PR DESCRIPTION
## What

zigbee log lines identify a device only by its IEEE address (`0x00158d00...`) or model name (`TS0601`). With several devices of the same model — or just a bare address — there is no way to tell which physical device a line refers to without looking the address up in the object tree. That is the request in #2735.

This routes every user-facing device reference in the log through a single helper that shows the **user-assigned name** when one is set, and falls back to the address otherwise:

```
before:  Failed to ping 0xa4c138... EGLO_ZM_RGB_TW for {"failed":1,"reported":0} attempts
after:   Failed to ping 'Kitchen - ceiling light' for {"failed":1,"reported":0} attempts
```

## How

- `utils.devLabel(adapter, idOrIeee)` resolves the name via `stController.verifyDeviceName` (the existing local-config name store) and returns the passed id/address when the device has no name. It never throws.
- A short `devLabel(idOrIeee)` method on `BaseExtension`, `ZigbeeController` and `StatesController` keeps the call sites readable.
- Applied across device query, configure, interview, ping / availability, send command, group membership, OTA, delayed action, announce / leave and the start-up device list.
- The name is wrapped in quotes (names commonly contain spaces), and the model that used to follow the address — now redundant next to the name — is dropped.

Object ids, state paths, `checkDebugDevice` matching and event payloads are deliberately left untouched — only human-readable message text changes.

## Not addressed

The `State value ... less than min/max` line is emitted by js-controller for a `setState` outside the object's declared min/max, not by the adapter, and keeps the object-id path.

## Testing

Verified on a live instance with ~40 mixed devices: device query, ping-failure, configure and interview lines all show the assigned name; devices without a name still show their address; the adapter connects and runs without errors. `npm test` and lint pass.

Addresses #2735
