### PR TITLE
fix: crash in onReady when the logLevel state is null

### DIFF
--- a/main.js
+++ b/main.js
@@ -219,7 +219,7 @@ class Zigbee extends adapterCore.Adapter {
 
         const dbActive = await this.getForeignState(`system.adapter.${this.namespace}.logLevel`);
         this.debugActive = (dbActive && dbActive.val === 'debug');
-        this.log.info('Adapter ready - starting subsystems. Adapter is running in '+dbActive.val+ ' mode.');
+        this.log.info('Adapter ready - starting subsystems. Adapter is running in '+(dbActive?.val ?? 'unknown')+ ' mode.');
         if (this.config.debugHerdsman) {
             if (debug) {
                 this.log.warn('Activating zigbee-herdsman debug connection - successful');


### PR DESCRIPTION
## What

`onReady` reads the adapter's own logLevel and already treats the result as possibly-null one line later (`this.debugActive = (dbActive && dbActive.val === 'debug')`), but the log line in between dereferences `dbActive.val` **without** the guard:

```js
const dbActive = await this.getForeignState(`system.adapter.${this.namespace}.logLevel`);
this.debugActive = (dbActive && dbActive.val === 'debug');
this.log.info('... running in '+dbActive.val+' mode.');   // <-- unguarded
```

When `getForeignState('system.adapter.<ns>.logLevel')` returns `null` — e.g. on a fresh start before that state has been created — this throws `TypeError: Cannot read properties of null (reading 'val')`, `onReady` aborts and the adapter never starts.

## Fix

Guard the value the same way the line below already does:

```js
this.log.info('... running in '+(dbActive?.val ?? 'unknown')+' mode.');
```

One line, no behaviour change when the state exists. The asymmetry — line 221 guards `dbActive`, line 222 didn't — is visible directly in the code.

## Testing

`npm test` and lint pass. Change is a null-guard on a log string only.
