### PR TITLE
fix: persist local config (device names) on shutdown

### DIFF
--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -1675,7 +1675,10 @@ class StatesController extends EventEmitter {
     */
 
     async stop() {
-        this.localConfig.retainData();
+        // Force an immediate synchronous flush on shutdown. retainData() without the flag only
+        // (re)arms the 500ms debounce timer, which never fires once onUnload tears the process
+        // down - so pending changes (e.g. a device rename via updateDeviceName) would be lost.
+        return this.localConfig.retainData(true);
     }
 }
 


### PR DESCRIPTION
## The problem

Renaming a Zigbee device stores the new name in localConfig **in memory only** (`updateDeviceName` just updates `localData.by_id[id].name`). The write to `LocalOverrides.json` is debounced: `retainData()` arms a 500 ms `setTimeout`.

On shutdown, `onUnload` awaits `StatesController.stop()`, which calls `retainData()` **without** the `isStopping` flag — so it only (re)arms that 500 ms timer (or, if one is already pending, returns immediately and does nothing). `onUnload` then runs its callback and the process is torn down, so the timer never fires. **Any change since the last flush — e.g. a device rename — is lost on the next restart.**

## The fix

`retainData(true)` already does the right thing for shutdown: it clears the pending debounce timer and writes synchronously (`writeFileSync`) immediately. `stop()` simply wasn't passing the flag:

```js
async stop() {
    return this.localConfig.retainData(true);   // was: retainData()
}
```

One line, using the mechanism that was already there.

## Reproduction

Rename a device, then restart the adapter promptly → the old name is back. With the fix the rename survives the restart.
