### PR TITLE
fix: clear StatesController timers on unload (use adapter-tracked timers)

### DIFF
--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -651,7 +651,7 @@ class StatesController extends EventEmitter {
             this.deviceQueryBlock.push(deviceId);
             const id = deviceId;
             this.emit('device_query', deviceId, debugID, has_elevated_debug, (devId) =>{
-                setTimeout(() => { const idx = this.deviceQueryBlock.indexOf(id);
+                this.adapter.setTimeout(() => { const idx = this.deviceQueryBlock.indexOf(id);
                     if (idx > -1) this.deviceQueryBlock.splice(idx);
                 }, 10000)
 
@@ -827,7 +827,7 @@ class StatesController extends EventEmitter {
 
     updateStateWithTimeout(dev_id, name, value, common, timeout, outValue) {
         this.updateState(dev_id, name, value, common);
-        setTimeout(() => this.updateState(dev_id, name, outValue, common), timeout);
+        this.adapter.setTimeout(() => this.updateState(dev_id, name, outValue, common), timeout);
     }
 
     deepCompare(item1, item2) {
@@ -1460,8 +1460,8 @@ class StatesController extends EventEmitter {
                             case 'lightingColorControl':
                                 {
                                     const handle = this.boundReads[key];
-                                    if (handle) clearTimeout(handle);
-                                    this.boundReads[key] = setTimeout(() => {
+                                    if (handle) this.adapter.clearTimeout(handle);
+                                    this.boundReads[key] = this.adapter.setTimeout(() => {
                                         try {
                                             this.adapter.emit('sendToZigbee', { message: {id:target.address, ep: target.endpoint, cid:cluster, cmd:'read', cmdType:'foundation',
                                                 zclData:{ 'currentHue':{}, 'currentSaturation':{}, 'currentX':{}, 'currentY':{}, 'colorTemperature':{}} }});
@@ -1475,8 +1475,8 @@ class StatesController extends EventEmitter {
                             case 'onOff':
                                 {
                                     const handle = this.boundReads[key];
-                                    if (handle) clearTimeout(handle);
-                                    this.boundReads[key] = setTimeout(() => {
+                                    if (handle) this.adapter.clearTimeout(handle);
+                                    this.boundReads[key] = this.adapter.setTimeout(() => {
                                         try {
                                             this.adapter.emit('sendToZigbee', { message: {id:target.address, ep: target.endpoint, cid:cluster, cmd:'read', cmdType:'foundation', zclData:{ 'onOff':{}} }});
                                             delete this.boundReads[key];
@@ -1489,8 +1489,8 @@ class StatesController extends EventEmitter {
                             case 'genLevelCtrl':
                                 {
                                     const handle = this.boundReads[key];
-                                    if (handle) clearTimeout(handle);
-                                    this.boundReads[key] = setTimeout(() => {
+                                    if (handle) this.adapter.clearTimeout(handle);
+                                    this.boundReads[key] = this.adapter.setTimeout(() => {
                                         try {
                                             this.adapter.emit('sendToZigbee', { message: {id:target.address, ep: target.endpoint, cid:cluster, cmd:'read', cmdType:'foundation', zclData:{ 'currentLevel':{}} }});
                                             //this.warn(`reading ${key}`);


### PR DESCRIPTION
## The problem

`StatesController` creates several timers with the **global** `setTimeout`, so they are not registered with adapter-core and are **not cleared on unload**:

- `updateStateWithTimeout` — its delayed `this.updateState(...)` fires on the torn-down adapter (a state write after unload).
- the per-cluster `boundReads` read-back timers (`lightingColorControl` / `onOff` / `genLevelCtrl`) and the `deviceQueryBlock` release timer keep firing on the dead adapter.

Under `compact:true` the JS context survives unload, so these zombie timers run against a controller that is already being rebuilt.

## The fix

Switch those timers to `this.adapter.setTimeout` / `this.adapter.clearTimeout` — exactly the pattern already used a few lines above for the `compositeData` timer. adapter-core then clears any pending timer automatically on unload. Delays and callbacks are unchanged, so there is no behaviour change during normal operation.

`node --check` and `eslint` pass; the diff is 8 one-token changes (`setTimeout` → `this.adapter.setTimeout`, `clearTimeout` → `this.adapter.clearTimeout`).

## Note

Sibling native timers in `zigbeecontroller` (`_permitJoinInterval`), `networkmap` (`mapTimeout`) and `zbDeviceAvailability` have the same pattern and can follow as separate small PRs.
