### PR TITLE
fix: clear device-availability timers on unload (use adapter-tracked timers)

### DIFF
--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -40,7 +40,7 @@ class DeviceAvailability extends BaseExtension {
         // force publish availability for new devices
         this.zigbee.on('new', (entity) => {
             // wait for 1s for creating device states
-            setTimeout(() =>
+            this.zigbee.adapter.setTimeout(() =>
                 this.publishAvailability(entity.device, true, true), 1000);
         });
         this.startDevicePingQueue = []; // simple fifo array for starting device pings
@@ -116,7 +116,7 @@ class DeviceAvailability extends BaseExtension {
         this.availability_timeout = Math.max(Math.min(this.number_of_registered_devices * AverageTimeBetweenPings, MaxAvailabilityTimeout), MinAvailabilityTimeout);
         this.startDevicePingQueue.push({device, entity});
         if (this.startDevicePingTimeout == null) {
-            this.startDevicePingTimeout = setTimeout(async () =>
+            this.startDevicePingTimeout = this.zigbee.adapter.setTimeout(async () =>
                 await this.startDevicePing(), this.startDevicePingDelay);
         }
     }
@@ -134,7 +134,7 @@ class DeviceAvailability extends BaseExtension {
         this.startDevicePingTimeout = null;
         const item = this.startDevicePingQueue.shift();
         if (this.startDevicePingQueue.length > 0) {
-            this.startDevicePingTimeout = setTimeout(async () =>
+            this.startDevicePingTimeout = this.zigbee.adapter.setTimeout(async () =>
                 await this.startDevicePing(), this.startDevicePingDelay);
         }
         if (item && item.hasOwnProperty('device')) {
@@ -173,7 +173,7 @@ class DeviceAvailability extends BaseExtension {
         }
         if (this.startReadDelay > 0 && readables.length > 0) {
             this.debug(`Triggering device_query on ${readables.length} devices in ${this.startReadDelay / 1000} seconds.`)
-            setTimeout(() => {
+            this.zigbee.adapter.setTimeout(() => {
                 readables.forEach(device =>
                     this.zigbee.doDeviceQuery(device, Date.now(), false).catch(error =>
                         this.warn(`device query for '${this.devLabel(device.ieeeAddr)}' failed: ${error && error.message ? error.message : error}`)));


### PR DESCRIPTION
## The problem

`zbDeviceAvailability` creates several timers with the **global** `setTimeout`. `stop()` only clears the per-device `this.timers`, so these are **not cleared on unload** and keep firing on the torn-down adapter (reachable under `compact:true`):

- the `on('new')` 1 s `publishAvailability(...)` timer,
- the `startDevicePingTimeout` queue-drain timer (set in two places),
- the `startReadDelay` batch that runs `doDeviceQuery` on every readable device.

## The fix

Switch those four to `this.zigbee.adapter.setTimeout`, so adapter-core clears any pending timer automatically on unload. Delays and callbacks are unchanged — no behaviour change during normal operation. The per-device `this.timers` entries are left as-is (they are already cleared in `stop()`).

Same idea as #2928 (StatesController), for the availability plugin. `node --check` and `eslint` pass.
