### PR TITLE
fix: resolve default device names (model) in log labels

### DIFF
--- a/lib/deviceLabel.js
+++ b/lib/deviceLabel.js
@@ -3,11 +3,13 @@
 const utils = require('./utils');
 
 /**
- * Resolve a device log label from any id/IEEE/group-id form. Looks up the user-assigned name via
- * the adapter's state controller (falling back to the model as default when the user has not
- * renamed the device); the id is always kept for unique identification (see
- * utils.deviceDisplayName). Never throws — a log line can never fail because of this. An invalid
- * id resolves to "unknown device" (via deviceDisplayName), a lookup failure to "failed to get name".
+ * Resolve a device log label from any id/IEEE/group-id form (with or without namespace prefix).
+ * Looks up the user-assigned name via the adapter's state controller; when the user has not
+ * renamed the device, the name of the device object (usually the model, cached by the state
+ * controller) is used, so an un-named device is labelled the same way the admin shows it. The id
+ * is always kept for unique identification (see utils.deviceDisplayName). Never throws — a log
+ * line can never fail because of this. An invalid id resolves to "unknown device" (via
+ * deviceDisplayName), a lookup failure to "failed to get name".
  *
  * Lives in its own module (not in utils) so that utils stays free of adapter-specific code.
  *
@@ -19,7 +21,8 @@ const utils = require('./utils');
 function devLabel(adapter, idOrIeee, model) {
     let name = 'unnamed';
     try {
-        const adId = utils.zbIdorIeeetoAdId(adapter, idOrIeee, false);
+        const bareId = adapter && adapter.namespace ? String(idOrIeee).replace(`${adapter.namespace}.`, '') : idOrIeee;
+        const adId = utils.zbIdorIeeetoAdId(adapter, bareId, false);
         if (adapter && adapter.stController && typeof adapter.stController.verifyDeviceName === 'function') {
             name = adapter.stController.verifyDeviceName(adId, model, model);
         }

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -649,6 +649,7 @@ class Groups {
                 }
 
                 const name = await this.stController.localConfig.NameForId(id, 'group', groups[j]);
+                this.stController.cacheDeviceName(id, name);
                 const icon = this.stController.localConfig.IconForId(id, 'group', await this.stController.getDefaultGroupIcon(id));
                 chain.push(new Promise(resolve => {
                     const isActive = false;

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -44,6 +44,9 @@ class StatesController extends EventEmitter {
         }
         this.bindingInfo = {};
         this.coordinatorIEEE = '0x0';
+        // in-memory mirror of the device/group object names (id without namespace -> common.name),
+        // so the default name is synchronously available for log labels (devLabel)
+        this.cachedDeviceNames = new Map();
 
         this.boundReads = {};
 
@@ -714,12 +717,36 @@ class StatesController extends EventEmitter {
             objName = (obj.common.type == 'group' ? stateId.replace('_',' ') : obj.common.type);
         }
         this.localConfig.updateDeviceName(stateId, newName);
+        this.cacheDeviceName(stateId, objName);
         if (this.debugActive) this.debug('rename device: newname ~' + newName + '~ objName ~' + objName + '~')
         this.adapter.extendObject(id, {common: {name: objName}});
     }
 
-    verifyDeviceName(id, model ,name) {
-        return this.localConfig.NameForId(id, model, name);
+    verifyDeviceName(id, model, name) {
+        return this.localConfig.NameForId(id, model, name ?? this.cachedDeviceNames.get(id));
+    }
+
+    // Prime the device name cache from the adapter's own device/group objects. Called once on
+    // startup (before the zigbee subsystem starts logging), so devLabel resolves the default
+    // name (usually the model, see updateDev) even for log lines which only have the ieee in
+    // scope. The cache is kept up to date by updateDev / renameDevice / syncGroups / deleteObj.
+    async loadDeviceNameCache() {
+        try {
+            const devices = await this.adapter.getDevicesAsync();
+            for (const device of devices) {
+                this.cacheDeviceName(device._id.replace(`${this.adapter.namespace}.`, ''), device.common ? device.common.name : undefined);
+            }
+        } catch (error) {
+            this.warn(`unable to load the device names: ${error && error.message ? error.message : 'no reason given'}`);
+        }
+    }
+
+    // Store the name written to a device/group object (id without namespace). Non-string or
+    // empty names are ignored - the cache only mirrors real object names.
+    cacheDeviceName(id, name) {
+        if (typeof id === 'string' && id.length > 0 && typeof name === 'string' && name.length > 0) {
+            this.cachedDeviceNames.set(id, name);
+        }
     }
 
     // Log label for a device: user-assigned name if set, otherwise the id/address.
@@ -747,6 +774,7 @@ class StatesController extends EventEmitter {
         const options = { recursive:true };
         try {
             await this.adapter.delObjectAsync(devId,options);
+            this.cachedDeviceNames.delete(devId);
             return {status:true};
         } catch (error) {
             this.adapter.log.warn(`Cannot delete Object '${this.devLabel(devId)}': ${error && error.message ? error.message : 'without error message'}`);
@@ -1039,8 +1067,9 @@ class StatesController extends EventEmitter {
                 common: myCommon,
                 native: { modelIcon: modelIcon, id:dev_id }
             });
+            this.cacheDeviceName(id, __dev_name);
         } else {
-            await this.adapter.setObjectNotExistsAsync(id, {
+            const created = await this.adapter.setObjectNotExistsAsync(id, {
                 type: 'device',
                 // actually this is an error, so device.common has no attribute type. It must be in native part
                 common: myCommon,
@@ -1049,6 +1078,9 @@ class StatesController extends EventEmitter {
                     modelIcon: modelIcon,
                 }
             });
+            // setObjectNotExists only writes (and returns an id) when the object did not exist -
+            // only mirror the name in that case, an existing object keeps its stored name.
+            if (created) this.cacheDeviceName(id, __dev_name);
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -238,6 +238,9 @@ class Zigbee extends adapterCore.Adapter {
         this.subscribeForeignStates(`system.adapter.${this.namespace}.logLevel`)
         // set connection false before connect to zigbee
         this.setState('info.connection', false, true);
+        // prime the device name cache before the zigbee subsystem starts logging, so devLabel
+        // resolves the stored (default) device names from the first log line on
+        await this.stController.loadDeviceNameCache();
         const zigbeeOptions = this.getZigbeeOptions();
         this.zbController = new ZigbeeController(this);
 


### PR DESCRIPTION
Follow-up to #2925, addresses the `unnamed` feedback in [#2927 (comment)](https://github.com/ioBroker/ioBroker.zigbee/pull/2927#issuecomment-4879883225).

Every device the user has not renamed was labelled `unnamed (<ieee>)`, although the adapter names those devices after their model in the object tree. Root cause: `devLabel` could only fall back to the default name via its third (`model`) parameter — and no call site passes it. Threading the model through the call sites would not have fixed it either, since many log sites (e.g. the availability ping path) only have the ieee in scope.

Instead, the default name is now readily accessible in the states controller, as suggested in the #2925 review:

- `StatesController` keeps an in-memory mirror of the device/group object names (`cachedDeviceNames`), primed from the adapter's own device objects in `onReady` (before the zigbee subsystem starts logging) and kept up to date by `updateDev`, `renameDevice`, the group sync and `deleteObj`.
- `verifyDeviceName` falls back to this mirror when no explicit default is supplied, so every `devLabel` call resolves to the same name the admin shows: user-assigned name → stored object name (usually the model) → `unnamed (id)` only when the adapter genuinely knows nothing yet (e.g. mid-pairing).
- `updateDev` only mirrors the name when the object was actually written — `setObjectNotExists` resolves an id only on creation — so an existing object keeps its stored name.
- `devLabel` now also accepts namespace-prefixed ids (as some admin messages send them); those previously resolved no name at all, not even a user-assigned one.

From the log in the report:

```
before: Failed to ping 'unnamed (0xd885acfffee9db88)' for {"failed":1,"reported":0} attempts
after:  Failed to ping 'S4PL-00416EU (0xd885acfffee9db88)' for {"failed":1,"reported":0} attempts
```

Testing: functional test against the real `localConfig`/`StatesController`/`deviceLabel` modules covering 27 scenarios (user-assigned name precedence, primed cache, explicit model parameter, namespace-prefixed ids, numeric group ids, rename/clear cycle, delete, prime-failure tolerance, empty/multilingual object names skipped), plus `npm test` and eslint. Verified on a live system (25+ devices): startup listing, availability pings, announce and device-query lines all resolve to the stored names — an un-renamed device now logs as `Device 'CK-TLSR8656-SS5-01(7000) (0xa4c138067b97ffff)' announced itself, trying to read its status` — with no `unnamed` left and no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
