### PR TITLE
Fix ignore_device_delete: TypeError on device leave, option lookup never matched

### DIFF
--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1061,8 +1061,8 @@ class ZigbeeController extends EventEmitter {
         if (this.localConfig.optionExists('ignore_device_delete')) {
             const entity = await this.resolveEntity(message.device || message.ieeeAddr);
             if (entity) {
-                if ((this.localConfig.getDeviceOption(entity.device.ieeeAddr, entity.model.modelID, false) ?? {}).ignore_device_delete) {
-                    this.warn(`Ignoring device_leave message from '${this.devLabel(message.ieeeAddr)}' (${entity.model.modelID})`);
+                if (this.localConfig.getDeviceOption(entity.device.ieeeAddr, entity.mapped?.model, 'ignore_device_delete', true)) {
+                    this.warn(`Ignoring device_leave message from '${this.devLabel(message.ieeeAddr)}' (${entity.device.modelID})`);
                     return;
                 }
             }


### PR DESCRIPTION
## The problem

`insertedDeviceLeave` is the spliced `deviceLeave` listener that is armed at every controller start. As soon as any device or model has the *ignore Delete* option set (that is exactly what the `optionExists('ignore_device_delete')` gate checks), the next `deviceLeave` for a resolvable device throws instead of ignoring the leave:

- `entity.model` does not exist on **any** `resolveEntity()` return shape — the device, group and coordinator branches all return `{type, device, mapped, endpoint, ...}` without a `model` key. `entity.model.modelID` is therefore a guaranteed `TypeError`, raised inside an async event listener → unhandled rejection.

Independently of the crash, the option lookup could never match: `getDeviceOption(device_id, model_id, option, dOnly)` was called with **three** arguments, so `option` was the literal `false` — the lookup returned `undefined`, and `(undefined ?? {}).ignore_device_delete` is always falsy. The feature was inert even where it did not crash.

## The fix

```js
if (this.localConfig.getDeviceOption(entity.device.ieeeAddr, entity.mapped?.model, 'ignore_device_delete', true)) {
    this.warn(`Ignoring device_leave message from '${this.devLabel(message.ieeeAddr)}' (${entity.device.modelID})`);
```

- the option is read by its real key, with `dOnly=true` so both the per-device and the per-model option resolve (the option is declared `byDevice: true, byModel: true` in the catalogue)
- `entity.mapped?.model` is the `by_model` key space the local config stores options under (`common.type`); `?.` keeps unsupported devices safe — `getDeviceOption` handles an undefined model
- the log prints the existing `entity.device.modelID`

## Verification

Functional test against the real `lib/localConfig.js`: the old 3-argument form provably returns `undefined` for a set option (per-device, stored under `.options` the way `updateConfigItems` persists it), the new call resolves the per-device option, the per-model option, and returns `undefined` for an unsupported device without a mapped model. `node --check`, ESLint and `npm test` green.

Note: #2934 touches the same warn line (it adds the model parameter to that `devLabel` call). Whichever lands second I will rebase promptly — the overlap is that one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)