### PR TITLE
Collect repeated send failures in the stashed-errors view instead of flooding the log

### DIFF
--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -461,6 +461,18 @@ class StatesController extends EventEmitter {
         catch { /* */ }
     }
 
+    // Drop a stashed error once its cause is resolved (e.g. a send to the device succeeded
+    // again), so the next occurrence is logged as a fresh error instead of silently counting.
+    unstashError(key) {
+        try {
+            if (this.stashedErrors.errors.hasOwnProperty(key)) {
+                delete this.stashedErrors.errors[key];
+                this.stashedErrors.hasData = Object.keys(this.stashedErrors.errors).length > 0 || Object.keys(this.stashedErrors.unknownModels).length > 0;
+            }
+        }
+        catch { /* */ }
+    }
+
     stashUnknownModel(model, msg) {
         try {
             if (!this.stashedErrors.unknownModels.hasOwnProperty(model)) {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1724,6 +1724,9 @@ class ZigbeeController extends EventEmitter {
                             }
                         }
                         retry = 0;
+                        // the send went through - a stashed send failure for this device is
+                        // resolved, the next failure is logged as a fresh error again
+                        this.adapter.stController?.unstashError(`send:${String(deviceId).replace('0x', '')}`);
                         if (readKeys) {
                             for (const readKey of readKeys) {
                                 if (readKey.converter) {
@@ -1753,8 +1756,10 @@ class ZigbeeController extends EventEmitter {
                         }
                         else {
                             retry = 0;
+                            // stash key: repeated send failures to the same device (e.g. while it
+                            // is unreachable) are counted instead of logged, until a send succeeds
                             this.adapter.filterError(`Error ${error.code} on send command to '${this.devLabel(deviceId)}'.` +
-                            ` Error: ${error.message}`, `Send command to ${deviceId} failed with`, error);
+                            ` Error: ${error.message}`, `Send command to ${deviceId} failed with`, error, `send:${String(deviceId).replace('0x', '')}`);
                         }
                     }
                 } while (retry > 0);

--- a/main.js
+++ b/main.js
@@ -166,11 +166,24 @@ class Zigbee extends adapterCore.Adapter {
         } */
     }
 
-    filterError(errormessage, message, error) {
+    // Error-level output of filterError. With a stash key, repeated identical errors
+    // (e.g. every failed send to an unreachable device, one per ~5 seconds) are collected
+    // by the states controller instead of flooding the log: the first one is logged as an
+    // error, the repeats only update the counter shown in the errors view of the admin
+    // tab and in info.lasterror. The caller clears the key once the cause is resolved.
+    logFilteredError(stashKey, text) {
+        if (stashKey && this.stController) {
+            this.stController.stashErrors(stashKey, `${text} - repeats are counted, not logged (errors view in the admin tab)`, true);
+        } else {
+            this.log.error(text);
+        }
+    }
+
+    filterError(errormessage, message, error, stashKey) {
         if (error != null && error.code == undefined) {
             let em = error.stack.match(/failed \((.+?)\) at/);
             em = em || error.stack.match(/failed \((.+?)\)/);
-            this.log.error(`${message} no error code (${(em ? em[1] : 'undefined')})`);
+            this.logFilteredError(stashKey, `${message} no error code (${(em ? em[1] : 'undefined')})`);
             this.sendError(error, `${message} no error code`);
             if (this.debugActive) this.log.debug(`Stack trace for ${em}: ${error.stack}`);
             return;
@@ -178,7 +191,7 @@ class Zigbee extends adapterCore.Adapter {
 
         const ecode = errorCodes[error.code];
         if (ecode === undefined) {
-            this.log.error(errormessage);
+            this.logFilteredError(stashKey, errormessage);
             this.sendError(error, errormessage);
             return;
         }
@@ -194,11 +207,11 @@ class Zigbee extends adapterCore.Adapter {
                 this.log.warn(`${message}: Code ${error.code} (${ecode.message})`);
                 break;
             case E_ERROR:
-                this.log.error(`${message}: Code ${error.code} (${ecode.message})`);
+                this.logFilteredError(stashKey, `${message}: Code ${error.code} (${ecode.message})`);
                 this.sendError(error, `${message}: Code ${error.code} (${ecode.message})`);
                 break;
             default:
-                this.log.error(`${message}: Code ${error.code} (malformed error)`);
+                this.logFilteredError(stashKey, `${message}: Code ${error.code} (malformed error)`);
                 this.sendError(error, `${message}: Code ${error.code} (malformed error)`);
                 break;
         }


### PR DESCRIPTION
## The problem

A device that stops responding (left the network, powered off) turns every send into an error line: the ember driver rejects with `Delivery failed for '<nwk>'` and **no error code**, so `filterError` takes the no-code branch and logs every attempt at error level. With an automation still commanding the device (a scene, a bridge, a script), the send queue drains one failed attempt per ~5 seconds — that is one identical log line per ~5 seconds, around the clock:

```
Send command to 0xa4c13878b2fbd388 failed with no error code (Delivery failed for '26566'.)
Send command to 0xa4c13878b2fbd388 failed with no error code (Delivery failed for '26566'.)
...
```

Observed live: ~18,000 identical lines per day for a single dead bulb. Every other message drowns in between, and the flood does not even show when the problem started.

## The fix — reuse the existing stashed-errors collection

The adapter already has exactly the right tool: the stashed-errors collection in the states controller (today used for the min/max value warnings and unknown models) — first occurrence is logged, repeats only bump a counter with first/last-seen timestamps, and the errors view in the admin tab plus `info.lasterror` show the live state.

This PR routes the **error-level** branches of `filterError` (no error code, unknown code, E_ERROR, malformed) through that collection when the caller provides a stash key; **without a key the behaviour is byte-for-byte unchanged**. The send path in `publishFromState` passes `send:<device>` as key and clears it again on the first successful send to that device — so a later outage starts with a fresh error line instead of counting silently. Clearing recalculates `hasData`, so the errors button disappears once everything is resolved. The first logged line carries a short hint that repeats are counted, not logged.

The info/warn/debug severities of the error-code table (9999 → info, 233 MAC NO ACK → debug, 205/134 → warn) are deliberately untouched — those are already rate-appropriate.

## Resulting behaviour for a dead device

- outage starts → **one** error line (as today, plus the hint)
- while it lasts → no further log lines; the errors view shows *message | count | first seen | last seen* live, `info.lasterror` is updated per occurrence
- device recovers, first send succeeds → collection entry cleared
- a new outage later → again exactly one fresh error line

## Verification

- 23-case functional test against the real modules (`main.js` `filterError`/`logFilteredError` + the real `StatesController`): one line then silence, counter/timestamps/`info.lasterror`, reset-on-success, fresh logging after reset, `hasData` recalculation with and without remaining entries, no-key behaviour unchanged (two calls = two lines), coded paths info/warn/debug unchanged and not collected, unknown-code path collected, existing min/max stash behaviour unchanged
- `node --check` on all touched files, ESLint clean, `npm test` green

Note: the `filterError` call site in `publishFromState` overlaps with a line #2934 touches (the devLabel model parameter). Whichever lands second, I will rebase immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)