### PR TITLE
Keep parentheses and plus sign in modelIcon URLs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -364,7 +364,7 @@ const ikeaTradfriManufacturerID = [4476];
  * @returns {the sanitized image name}
  */
 function sanitizeImageParameter(parameter) {
-    const replaceByDash = [/\?/g, /&/g, /[^a-z\d\-_./:]/gi, /[/]/gi];
+    const replaceByDash = [/\?/g, /&/g, /[^a-z\d\-_./:()+]/gi, /[/]/gi];
     let sanitized = parameter || 'illegalParameter';
     replaceByDash.forEach(r => sanitized = sanitized.replace(r, '-'));
     return sanitized;


### PR DESCRIPTION
## The problem

Devices whose model name contains parentheses or a plus sign show the default "unavailable" icon, and the icon download fails with HTTP 404. The reported case is `CK-TLSR8656-SS5-01(7014)`; the same class also hits e.g. Yale locks like `YMF40/YDM4109+/YDF40`.

`sanitizeImageParameter` replaced every character outside `[a-z\d\-_./:]` with a dash, so `CK-TLSR8656-SS5-01(7014)` became `CK-TLSR8656-SS5-01-7014-` and the generated URL 404'd:

```
generated: https://www.zigbee2mqtt.io/images/devices/CK-TLSR8656-SS5-01-7014-.png   -> 404
actual:    https://www.zigbee2mqtt.io/images/devices/CK-TLSR8656-SS5-01(7014).png    -> 200
```

## The fix

The z2m image filename is an exact match of the device model — herdsman-converters keeps `(`, `)` and `+` verbatim; only `/` and spaces are turned into `-`. Adding `()` and `+` to the allowed character class is the whole change:

```diff
- const replaceByDash = [/\?/g, /&/g, /[^a-z\d\-_./:]/gi, /[/]/gi];
+ const replaceByDash = [/\?/g, /&/g, /[^a-z\d\-_./:()+]/gi, /[/]/gi];
```

Verified against the live image server (herdsman-converters 26.73.0):

| model | resulting filename | HTTP |
|-------|--------------------|------|
| `CK-TLSR8656-SS5-01(7014)` | `…SS5-01(7014).png` | 200 |
| `CK-BL702-ROUTER-01(7018)` | `…ROUTER-01(7018).png` | 200 |
| `YMF40/YDM4109+/YDF40` | `YMF40-YDM4109+-YDF40.png` | 200 |
| `AV2010/14` | `AV2010-14.png` | 200 |
| `AE 260` | `AE-260.png` | 200 |

This fixes every parens (31) and plus (39) model without changing the slash (117) or space (738) models, whose dash replacement stays correct. `?` and `&` are still replaced.

## Existing devices

`modelIcon` is rebuilt on every coordinator connect (`doConnect` → `syncAllDeviceStates` → `updateDev` writes `native.modelIcon` for every known device), so devices that already stored the bad URL are corrected on the next adapter restart — no re-pairing needed.

## Test plan

- [x] Functional test over the public `getDeviceIcon` for the five models above plus a `?`/`&` case (unchanged → dash) — red before the change, green after
- [x] `npm run test:package` (56 passing) and `npm run test:unit` pass
- [x] `npm run lint` clean, `node --check lib/utils.js` ok

Addresses #2896

🤖 Generated with [Claude Code](https://claude.com/claude-code)