### PR TITLE
Register custom clusters on first pairing, not only after restart

### DIFF
--- a/lib/zbDeviceEvent.js
+++ b/lib/zbDeviceEvent.js
@@ -6,6 +6,10 @@ class DeviceEvent extends BaseExtension {
     constructor(zigbee, options) {
         super(zigbee, options);
         this.name = 'DeviceEvent';
+        // Devices that already received a 'start' onEvent. A freshly paired device only gets
+        // 'deviceJoined'/'deviceInterview', so we synthesise its 'start' on the first such event
+        // (see callOnEvent, issue #2915).
+        this.startCalled = new Set();
     }
 
     async onZigbeeStarted() {
@@ -42,6 +46,27 @@ class DeviceEvent extends BaseExtension {
         if (!device) return;
 
         const baseData = {device, deviceExposesChanged: function() { }, options: data.options || {}, state: data.state || {}}
+
+        // #2915: a freshly paired device never receives a 'start' event - it only sees
+        // 'deviceJoined'/'deviceInterview'. modernExtend onEvent handlers that key on 'start'
+        // (e.g. deviceAddCustomCluster) therefore never register their custom clusters until the
+        // next adapter restart, and incoming frames on those clusters throw UNSUPPORTED_CLUSTER.
+        // Mirror zigbee2mqtt's onEvent extension: the first time a device is seen with any
+        // non-start/non-stop event, run its 'start' handlers first. If the model is not resolvable
+        // yet (md is null early during a join) this is a no-op and retried on the next event.
+        if (type === 'start') {
+            this.startCalled.add(device.ieeeAddr);
+        } else if (type === 'stop') {
+            this.startCalled.delete(device.ieeeAddr);
+        } else if (md && md.onEvent && !this.startCalled.has(device.ieeeAddr)) {
+            this.startCalled.add(device.ieeeAddr);
+            try {
+                await md.onEvent({type: 'start', data: baseData});
+            } catch (error) {
+                this.warn(`Error in start onEvent for '${this.devLabel(device.ieeeAddr, md.model)}': ${error && error.message ? error.message : 'no message'}`);
+            }
+        }
+
         const eventData = {
             type,
         }

--- a/lib/zbDeviceEvent.test.js
+++ b/lib/zbDeviceEvent.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// Regression test for #2915: custom clusters must be registered when a device is paired for the
+// first time, not only after an adapter restart. Runs the real DeviceEvent extension against a real
+// zigbee-herdsman-converters definition that uses deviceAddCustomCluster (Develco AQSZB-110), with a
+// mocked device object - no Zigbee hardware required.
+//
+// Run with:  node --test lib/zbDeviceEvent.test.js
+// (uses Node's built-in test runner + assert, so it needs no test framework)
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const DeviceEvent = require('./zbDeviceEvent');
+
+// Minimal stub of the `zigbee` object - only the surface BaseExtension/DeviceEvent actually touch.
+function mkZigbee() {
+    return {
+        adapter: { name: 'zigbee', namespace: 'zigbee.0', log: { debug() {}, info() {}, warn() {}, error() {} } },
+        info() {}, warn() {}, error() {}, debug() {}, sendError() {},
+        getClientIterator: () => [],
+        resolveEntity: async () => null,
+    };
+}
+
+// A fresh Develco AQSZB-110. Its definition adds the custom clusters genBasic (manufacturer-specific)
+// and manuSpecificDevelcoAirQuality via deviceAddCustomCluster - exactly the class of device in #2915.
+function mkDevice(modelID = 'AQSZB-110') {
+    const ep = {
+        ID: 38, deviceIeeeAddress: '0x0015bc0000000001',
+        getClusterAttributeValue: () => undefined, supportsInputCluster: () => true, supportsOutputCluster: () => true,
+        getInputClusters: () => [], getOutputClusters: () => [], saveClusterAttributeKeyValue: () => {},
+        read: async () => ({}), write: async () => ({}), bind: async () => ({}), configureReporting: async () => ({}), clusters: {},
+    };
+    return {
+        modelID, manufacturerName: 'Develco', manufacturerID: 4117, type: 'EndDevice',
+        ieeeAddr: '0x0015bc0000000001', endpoints: [ep], getEndpoint: () => ep, options: {},
+        customClusters: {}, addCustomCluster(name, def) { this.customClusters[name] = def; }, save() {}, meta: {},
+    };
+}
+
+describe('DeviceEvent: custom-cluster registration on first pairing (#2915)', () => {
+    it('registers custom clusters on a fresh pairing (deviceInterview, no prior start)', async () => {
+        const dev = mkDevice();
+        const ext = new DeviceEvent(mkZigbee(), {});
+        // Simulate the pairing path: interview completes, 'start' was never fired for this device.
+        await ext.callOnEvent(dev, 'deviceInterview', { device: dev, status: 'successful' });
+        // Without the synthetic-start guard these stay empty and the next incoming frame on the
+        // custom cluster throws UNSUPPORTED_CLUSTER.
+        const keys = Object.keys(dev.customClusters);
+        assert.ok(keys.includes('genBasic'), `expected genBasic, got: ${keys.join(', ') || '(none)'}`);
+        assert.ok(keys.includes('manuSpecificDevelcoAirQuality'), `expected manuSpecificDevelcoAirQuality, got: ${keys.join(', ') || '(none)'}`);
+    });
+
+    it('does not synthesise a second start once a device has been started', async () => {
+        const dev = mkDevice();
+        const ext = new DeviceEvent(mkZigbee(), {});
+        await ext.callOnEvent(dev, 'start', { device: dev });
+        let addsAfterStart = 0;
+        const orig = dev.addCustomCluster.bind(dev);
+        dev.addCustomCluster = (n, d) => { addsAfterStart++; return orig(n, d); };
+        await ext.callOnEvent(dev, 'deviceAnnounce', { device: dev });
+        assert.strictEqual(addsAfterStart, 0);
+    });
+
+    it('is a no-op (no throw) while the model is unresolved, and retries once it resolves', async () => {
+        const dev = mkDevice('TOTALLY-UNKNOWN-XYZ'); // findByDevice -> undefined early during join
+        dev.manufacturerName = 'NoSuchVendor';
+        dev.manufacturerID = 0;
+        const ext = new DeviceEvent(mkZigbee(), {});
+        await ext.callOnEvent(dev, 'deviceJoined', { device: dev }); // must not throw
+        assert.strictEqual(Object.keys(dev.customClusters).length, 0);
+        // model becomes resolvable on a later event -> start is synthesised then
+        dev.modelID = 'AQSZB-110';
+        dev.manufacturerName = 'Develco';
+        dev.manufacturerID = 4117;
+        await ext.callOnEvent(dev, 'deviceInterview', { device: dev, status: 'successful' });
+        assert.ok(Object.keys(dev.customClusters).includes('manuSpecificDevelcoAirQuality'));
+    });
+
+    it('re-arms the synthetic start after a device stops (so a re-join registers again)', async () => {
+        const dev = mkDevice();
+        const ext = new DeviceEvent(mkZigbee(), {});
+        await ext.callOnEvent(dev, 'start', { device: dev });
+        await ext.callOnEvent(dev, 'stop', { device: dev, ieeeAddr: dev.ieeeAddr });
+        dev.customClusters = {};
+        await ext.callOnEvent(dev, 'deviceInterview', { device: dev, status: 'successful' });
+        assert.ok(Object.keys(dev.customClusters).includes('genBasic'));
+    });
+});


### PR DESCRIPTION
## The problem

`deviceAddCustomCluster` (herdsman `modernExtend`) registers a device's custom clusters via two paths: its `configure` chain, and an `onEvent` handler keyed on `event.type === 'start'`. In this adapter `'start'` is only ever fired from `onZigbeeStarted` — i.e. for devices that already exist at adapter start (`zbDeviceEvent.js`). A **freshly paired** device only sees `deviceJoined`/`deviceInterview`, never `'start'`, so that handler never runs for it and its custom clusters aren't registered until the next restart. An incoming frame on an unregistered custom cluster then fails to parse in herdsman's `getCluster()` with `UNSUPPORTED_CLUSTER`.

This matches the report, including why a restart or re-pair fixes it: on restart `onZigbeeStarted` fires `'start'` for every device and registers the clusters up front.

**Verified without hardware (deterministic):** running the real `DeviceEvent` extension against a real herdsman definition using `deviceAddCustomCluster` (Develco AQSZB-110) with a mocked device — `device.customClusters` stays **empty** after a `deviceInterview` on the current code, and is populated after `'start'`. The regression test below fails on the current code and passes with the fix.

**Not verified (timing — your hardware):** whether, in practice, a frame actually lands on the custom cluster *before* the cluster is registered. `configure` also registers it, just later/queued, so the window is real but timing-dependent. That last link between this asymmetry and the exact error you observe is the one thing I'm asking you to confirm.

## The fix

Mirror zigbee2mqtt's onEvent extension (`lib/extension/onEvent.ts`): track which devices already received a `'start'`, and the first time a device is seen with any non-`start`/`stop` event, synthesise `'start'` first so its custom clusters are registered before the real event is dispatched. No-op + retried on the next event if the model isn't resolvable yet during a join.

```js
if (type === 'start') {
    this.startCalled.add(device.ieeeAddr);
} else if (type === 'stop') {
    this.startCalled.delete(device.ieeeAddr);
} else if (md && md.onEvent && !this.startCalled.has(device.ieeeAddr)) {
    this.startCalled.add(device.ieeeAddr);
    await md.onEvent({ type: 'start', data: baseData });
}
```

## Test

`lib/zbDeviceEvent.test.js` — Node's built-in runner, no framework, no hardware:

```
node --test lib/zbDeviceEvent.test.js
```

Covers: custom clusters registered on a fresh pairing; no second synthetic start once started; no-op + retry while the model is unresolved; re-arm after stop. (I used `node:test` because `npm run test:js` currently errors on the deprecated mocha `--opts` — I did not touch the test setup.)

## Notes

- `npm run test:package` (56) and `npm run test:unit` pass; ESLint clean.
- I have no custom-cluster device to reproduce on hardware. If the timing matches what you see this should close it; if not, the asymmetry is still real and worth fixing on its own.

Addresses #2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)