### PR TITLE
fix: group composite color states by compositeKey, not compositeState

### DIFF
--- a/lib/statescontroller.composite.test.js
+++ b/lib/statescontroller.composite.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+
+const StatesController = require('./statescontroller');
+const { states } = require('./models');
+
+const IEEE = '0xa4c13878b2fbd388';
+const ID = 'a4c13878b2fbd388';
+
+// All color states share compositeState 'color' and are always offered together,
+// exactly as statescontroller receives them from devStates.states.
+const ALL_COLOR_DEFS = [
+    states.color_hue,
+    states.color_saturation,
+    states.color_red,
+    states.color_green,
+    states.color_blue,
+];
+
+class FakeAdapter extends EventEmitter {
+    constructor(stateStore) {
+        super();
+        this.stateStore = stateStore;
+        this.written = [];
+        this.localConfig = { getOverrideWithKey: () => undefined, NameForId: (id) => id };
+        this.log = { debug() {}, info() {}, warn() {}, error() {}, silly() {} };
+    }
+    setTimeout(fn, ms) { return setTimeout(fn, ms); }
+    clearTimeout(handle) { clearTimeout(handle); }
+    async getState(id) { return this.stateStore[id]; }
+    setState(id, val) { this.written.push({ id, val }); }
+    getStatesOf() {}
+}
+
+function buildController(stateStore) {
+    const adapter = new FakeAdapter(stateStore);
+    const controller = new StatesController(adapter);
+    return { adapter, controller };
+}
+
+const waitForComposite = () => new Promise((resolve) => setTimeout(resolve, 900));
+
+describe('triggerComposite groups color states by compositeKey', () => {
+    test('hue/saturation must not be polluted by the cached rgb values', async () => {
+        // Real-world state: lamp currently shows blue, so color_rgb holds that blue.
+        // User now sets pure red via hue/saturation.
+        const { adapter, controller } = buildController({
+            [`${ID}.color_hs.hue`]: { val: 0 },
+            [`${ID}.color_hs.saturation`]: { val: 100 },
+            [`${ID}.color_rgb.r`]: { val: 0 },
+            [`${ID}.color_rgb.g`]: { val: 128 },
+            [`${ID}.color_rgb.b`]: { val: 255 },
+        });
+
+        await controller.triggerComposite(IEEE, states.color_hue, false, ALL_COLOR_DEFS);
+        await waitForComposite();
+
+        const write = adapter.written.find((w) => w.id === `${ID}.color`);
+        assert.ok(write, 'composite must write the color state');
+        const payload = JSON.parse(write.val);
+
+        // The whole point: zigbee-herdsman-converters decides hs vs xy by inspecting
+        // the payload. Any r/g/b key makes Color.fromConverterArg() report isRGB(),
+        // which routes to moveToColor(xy) and silently drops the hue/saturation intent.
+        assert.deepStrictEqual(payload, { hue: 0, saturation: 100 });
+    });
+
+    test('rgb components are still grouped together', async () => {
+        const { adapter, controller } = buildController({
+            [`${ID}.color_hs.hue`]: { val: 0 },
+            [`${ID}.color_hs.saturation`]: { val: 100 },
+            [`${ID}.color_rgb.r`]: { val: 255 },
+            [`${ID}.color_rgb.g`]: { val: 0 },
+            [`${ID}.color_rgb.b`]: { val: 0 },
+        });
+
+        await controller.triggerComposite(IEEE, states.color_red, false, ALL_COLOR_DEFS);
+        await waitForComposite();
+
+        const write = adapter.written.find((w) => w.id === `${ID}.color`);
+        assert.ok(write, 'composite must write the color state');
+        assert.deepStrictEqual(JSON.parse(write.val), { r: 255, g: 0, b: 0 });
+    });
+});

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -495,7 +495,9 @@ class StatesController extends EventEmitter {
         const idParts = stateDesc.id.split('.').slice(-2);
         const key = `${deviceId}.${idParts[0]}`;
         if (this.compositeData[key] == undefined)
-            this.compositeData[key] = {triggers: [stateDesc.id], stateDefinitions:stateDefinitions.filter((d) => d.compositeState == stateDesc.compositeState)};
+            // group by compositeKey, not compositeState: color_rgb and color_hs share the same
+            // compositeState ('color'), so filtering on it mixes r/g/b with hue/saturation.
+            this.compositeData[key] = {triggers: [stateDesc.id], stateDefinitions:stateDefinitions.filter((d) => d.compositeKey == stateDesc.compositeKey)};
         else this.compositeData[key].triggers.push(stateDesc.id);
         //this.compositeData[key].stateDefinitions = stateDefinitions;
         const handle = this.compositeData[key].handle;


### PR DESCRIPTION
## What happens

Setting `color_hs.hue` / `color_hs.saturation` does not apply hue/saturation. The light either keeps its previous color or jumps to an unrelated one. On devices that handle xy poorly, the command is dropped entirely.

## Why

`triggerComposite()` builds its cache key from the state **group**, but filters the state definitions by `compositeState`:

```js
const idParts = stateDesc.id.split('.').slice(-2);
const key = `${deviceId}.${idParts[0]}`;                                  // -> "<dev>.color_hs"
this.compositeData[key] = {triggers: [stateDesc.id],
    stateDefinitions: stateDefinitions.filter((d) => d.compositeState == stateDesc.compositeState)};
```

`compositeState` is `'color'` for **every** color state — `color_xy` (x/y), `color_rgb` (r/g/b) and `color_hs` (hue/saturation) all share it, in `models.js` as well as in the exposes path (`exposes.js`, `channelWithEp`). They are only distinguished by `compositeKey`, which is exactly what the key two lines above is built from.

So the collector loop picks up the **cached values of the other groups** and publishes a mixed payload:

```
{ hue: 0, saturation: 100, r: 0, g: 128, b: 255 }
```

zigbee-herdsman-converters decides between hue/saturation and xy by inspecting that payload — any `r`/`g`/`b` key makes `Color.fromConverterArg()` report `isRGB()`, so `light_color` takes the `else` branch and sends `moveToColor` (xy). The hue/saturation intent is silently dropped, and the xy value is derived from whatever color was cached before.

Filtering by `compositeKey` matches how the key is built and keeps the groups apart. Generic composites are unaffected: `exposes.js` sets `compositeKey` and `compositeState` to the same `channelID` there, so the filter behaves identically.

## Why this is easy to miss

On lights with solid xy support this mostly looks cosmetic — the payload still carries a color, it just arrives as `color_mode: xy` instead of `hs`. It only becomes visible when a device does not accept a specific xy coordinate.

Reported live on an EGLO/AwoX `EGLO_ZM_RGB_TW` (ember coordinator): red via RGB/xy is discarded by the firmware and the lamp does not change at all, while the identical color via `moveToHueAndSaturation` works. Sending hue/saturation through `send_payload` (which bypasses the composite path) produces `color_mode: "hs"` and the light responds immediately — through `color_hs.*` it never did. Green over hs is correct, so the hue scale itself is fine. This matches https://github.com/Koenkk/zigbee2mqtt/issues/18941 ("Only by sending hue and saturation payload does it change to color mode hs").

## Test

`lib/statescontroller.composite.test.js` (node:test, runs the real `StatesController` against a fake adapter):

- `node --test lib/statescontroller.composite.test.js`
- without the fix: `actual: { hue: 0, saturation: 100, r: 0, g: 128, b: 255 }` — fails
- with the fix: `{ hue: 0, saturation: 100 }` — 2/2 pass, second test asserts `color_rgb` still groups as `{r, g, b}`

The test uses `node:test` rather than the repo's mocha setup, since `test:js` currently does not run; it is meant as a reproduction, not as a CI guard. Happy to drop it if you prefer.

`npm test` and eslint are clean.