### PR TITLE
fix: do not list devices which have left the network

### DIFF
--- a/lib/devicemgmt.js
+++ b/lib/devicemgmt.js
@@ -41,6 +41,14 @@ class dmZigbee extends dmUtils.DeviceManagement {
     }
 
 
+    /**
+     * Drop the cached device list. loadDevices() keeps it for 10 seconds, which is long enough for
+     * a device that just left the network to keep its tile after its object is already gone.
+     */
+    invalidateDeviceCache() {
+        dmInfo.ts = -1;
+    }
+
     async handleRefresh(context) {
         this.adapter.log.info('handleRefresh');
         const getDevicesResult = await this.adapter.getDeviceInformation();

--- a/main.js
+++ b/main.js
@@ -255,6 +255,9 @@ class Zigbee extends adapterCore.Adapter {
         this.zbController.on('disconnect', this.onZigbeeAdapterDisconnected.bind(this));
         this.zbController.on('new', this.newDevice.bind(this));
         this.zbController.on('leave', this.stController.leaveDevice.bind(this.stController));
+        // the device manager serves its list from a 10 second cache, so drop it here - otherwise the
+        // tile of the departed device outlives its object by that much
+        this.zbController.on('leave', () => this.deviceManagement.invalidateDeviceCache());
         this.zbController.on('announce', this.stController.announceDevice.bind(this));
         this.zbController.on('pairing', this.onPairing.bind(this));
         this.zbController.on('event', this.stController.onZigbeeEvent.bind(this.stController));

--- a/main.js
+++ b/main.js
@@ -1229,16 +1229,36 @@ class Zigbee extends adapterCore.Adapter {
 
     async getDeviceInformation(id) {
         const roomsEnum = await this.getEnumsAsync('enum.rooms') || {};
-        const deviceObjects = (id ? [await this.getObjectAsync(id)] : await this.getDevicesAsync());
+        const objects = (id ? [await this.getObjectAsync(id)] : await this.getDevicesAsync());
         const all_states = id ? await this.getStatesAsync(id + '.*') : await this.getStatesAsync('*');
         const all_stateDefs = id ? await this.getStatesOfAsync(id) : await this.getStatesOfAsync();
 
         const groups = {};
         const PromiseChain = [];
         const models = { byUID : {}, UIDbyModel: {} };
-        for (const deviceObject of deviceObjects) {
-            const id = utils.getZbId(deviceObject._id);
-            const entity = await this.zbController.resolveEntity(id);
+        // Only objects which still have a device in the zigbee database are reported. The list is
+        // built from the ioBroker objects, so a device which just left the network is still in it:
+        // leaveDevice() deletes the object without awaiting it, and the device is gone from the
+        // database first. Such an object must not become a tile - the device is not part of the
+        // network any more. Nothing is stranded by leaving it out: the object is already being
+        // deleted, and anything left over from a failed delete is removed on the next start
+        // (onReady removes every object which no longer links to an active device).
+        const deviceObjects = [];
+        for (const deviceObject of objects) {
+            if (!deviceObject) {
+                // getObjectAsync returns null once the object is gone, which is the same race seen
+                // from the single device side: the admin asks for a device whose object has just
+                // been deleted.
+                this.log.debug(`no object for the requested device '${id}' - not listing it`);
+                continue;
+            }
+            const zbId = utils.getZbId(deviceObject._id);
+            const entity = await this.zbController.resolveEntity(zbId);
+            if (!entity) {
+                this.log.debug(`${deviceObject._id} has no device in the zigbee database - not listing it`);
+                continue;
+            }
+            deviceObjects.push(deviceObject);
             if (deviceObject._id.indexOf('group') > -1) {
                 PromiseChain.push(this.handleGroupforInfo(deviceObject, groups));
             }

--- a/test/deviceInfo.test.js
+++ b/test/deviceInfo.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+// Regression test for getDeviceInformation() when an object has no device in the zigbee database.
+//
+// getDeviceInformation() builds its list from the ioBroker OBJECTS. leaveDevice() deletes the object
+// of a device which left the network without awaiting it, while the device is already gone from the
+// herdsman database, so a call which started just before still sees the object and resolveEntity()
+// returns undefined for it. Such an object must not be reported - the device is not part of the
+// network - and reporting it used to take the adapter down: buildDeviceInfo() returned {} and
+// fillInfo() dereferenced models.byUID[UID].model.type on it.
+//
+// Runs the real Zigbee class from main.js against a stubbed @iobroker/adapter-core; no hardware.
+// Run:  node --test test/deviceInfo.test.js
+
+const Module = require('node:module');
+const { EventEmitter } = require('node:events');
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+// main.js and the lib modules import @iobroker/adapter-core; stub it so require() does not pull in
+// js-controller. The Adapter base class only has to provide what the constructor chain touches.
+class FakeAdapterBase extends EventEmitter {
+    constructor() {
+        super();
+        this.name = 'zigbee';
+        this.namespace = 'zigbee.0';
+        this.config = {};
+        this.log = { debug() {}, info() {}, warn() {}, error() {}, level: 'info' };
+    }
+    expandFileName(f) {
+        return '/nonexistent/' + f;
+    }
+    setTimeout() {}
+    clearTimeout() {}
+    setInterval() {}
+    clearInterval() {}
+    getStateAsync() {
+        return Promise.resolve(null);
+    }
+    subscribeStates() {}
+}
+
+const origLoad = Module._load;
+Module._load = function (request, ...rest) {
+    if (request === '@iobroker/adapter-core') return { Adapter: FakeAdapterBase };
+    return origLoad.call(this, request, ...rest);
+};
+
+const factory = require('../main.js');
+
+const LIVE_IEEE = '0xa085e3fffeb62fac';
+const LIVE_ADID = 'a085e3fffeb62fac';
+const GONE_ADID = '08b95ffffed911c9';
+
+function deviceObject(adId, name, type) {
+    return { _id: `zigbee.0.${adId}`, common: { name, type }, native: { id: adId } };
+}
+
+function liveEntity() {
+    return {
+        device: {
+            modelID: 'TS0011',
+            type: 'Router',
+            ieeeAddr: LIVE_IEEE,
+            networkAddress: 4711,
+            interviewState: 'SUCCESSFUL',
+            powerSource: 'Mains (single phase)',
+        },
+        endpoints: [{ ID: 1, profileID: 260, inputClusters: [0, 4, 6], outputClusters: [25] }],
+        mapped: { model: 'TS0011', description: 'Switch', vendor: 'Tuya', options: [], exposes: [] },
+        name: 'TS0011',
+    };
+}
+
+function groupEntity(groupID) {
+    return { type: 'group', mapped: { model: 'group' }, device: { groupID }, name: `Group ${groupID}` };
+}
+
+// Adapter with the data access it uses in getDeviceInformation stubbed out. `entities` maps the key
+// resolveEntity() is called with (0x<ieee> for devices, the number for groups) to the entity.
+function mkAdapter(objects, entities) {
+    const adapter = factory({});
+    adapter.stController.localConfig.localData = { by_id: {}, by_model: {} };
+    adapter.getEnumsAsync = () => Promise.resolve({});
+    adapter.getDevicesAsync = () => Promise.resolve(objects);
+    adapter.getObjectAsync = () => Promise.resolve(null);
+    adapter.getStatesAsync = () => Promise.resolve({});
+    adapter.getStatesOfAsync = () => Promise.resolve([]);
+    adapter.zbController = {
+        resolveEntity: (key) => Promise.resolve(entities[key]),
+        getClientIterator: () => [].values(),
+        getGroupMembersFromController: () => Promise.resolve([]),
+        callExtensionMethod: () => Promise.resolve([]),
+    };
+    return adapter;
+}
+
+const listedIds = (result) => result.deviceObjects.map((d) => d._id);
+
+describe('getDeviceInformation with an object whose device left the network', () => {
+    it('does not throw while a device is leaving', async () => {
+        const adapter = mkAdapter(
+            [deviceObject(GONE_ADID, 'Flur - Sensor', 'TS0011')],
+            {}, // herdsman no longer knows the device
+        );
+
+        await adapter.getDeviceInformation();
+    });
+
+    it('does not report the device - it is not part of the network any more', async () => {
+        const adapter = mkAdapter([deviceObject(GONE_ADID, 'Flur - Sensor', 'TS0011')], {});
+
+        const result = await adapter.getDeviceInformation();
+
+        assert.deepStrictEqual(listedIds(result), []);
+    });
+
+    it('reports the devices which are still in the network', async () => {
+        const adapter = mkAdapter(
+            [deviceObject(LIVE_ADID, 'Klo - Lüfter', 'TS0011'), deviceObject(GONE_ADID, 'Flur - Sensor', 'TS0011')],
+            { [LIVE_IEEE]: liveEntity() },
+        );
+
+        const result = await adapter.getDeviceInformation();
+
+        assert.deepStrictEqual(listedIds(result), [`zigbee.0.${LIVE_ADID}`]);
+    });
+
+    it('builds the full info block for a device which is still there', async () => {
+        const adapter = mkAdapter([deviceObject(LIVE_ADID, 'Klo - Lüfter', 'TS0011')], { [LIVE_IEEE]: liveEntity() });
+
+        const result = await adapter.getDeviceInformation();
+
+        const info = result.deviceObjects[0].info;
+        assert.strictEqual(info.device.ieee, LIVE_IEEE);
+        assert.strictEqual(info.device.type, 'Router');
+        assert.strictEqual(info.mapped.model, 'TS0011');
+        assert.strictEqual(info.endpoints.length, 1);
+    });
+
+    it('keeps groups - they resolve through the controller and are not devices', async () => {
+        const adapter = mkAdapter([{ _id: 'zigbee.0.group_5', common: { name: 'Küche', type: 'group' }, native: { id: 5 } }], {
+            5: groupEntity(5),
+        });
+
+        const result = await adapter.getDeviceInformation();
+
+        assert.deepStrictEqual(listedIds(result), ['zigbee.0.group_5']);
+    });
+
+    it('asking for the single device which just left returns nothing instead of failing', async () => {
+        const adapter = mkAdapter([], {});
+        adapter.getObjectAsync = () => Promise.resolve(deviceObject(GONE_ADID, 'Flur - Sensor', 'TS0011'));
+
+        const result = await adapter.getDeviceInformation(`zigbee.0.${GONE_ADID}`);
+
+        assert.deepStrictEqual(listedIds(result), []);
+    });
+
+    it('asking for a device whose object is already deleted returns nothing instead of failing', async () => {
+        // same race from the other side: the object is gone before the admin asks for it, so
+        // getObjectAsync answers null
+        const adapter = mkAdapter([], {});
+        adapter.getObjectAsync = () => Promise.resolve(null);
+
+        const result = await adapter.getDeviceInformation(`zigbee.0.${GONE_ADID}`);
+
+        assert.deepStrictEqual(listedIds(result), []);
+    });
+});

--- a/test/deviceManagerCache.test.js
+++ b/test/deviceManagerCache.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+// The device manager serves its device list from a 10 second cache. A device which leaves the
+// network loses its object right away, so without dropping that cache its tile outlives the device
+// by up to ten seconds. invalidateDeviceCache() is what the leave event calls.
+//
+// Runs the real dmZigbee class against a stubbed @iobroker/adapter-core; no hardware.
+// Run:  node --test test/deviceManagerCache.test.js
+
+const Module = require('node:module');
+const { EventEmitter } = require('node:events');
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const origLoad = Module._load;
+Module._load = function (request, ...rest) {
+    if (request === '@iobroker/adapter-core') return { Adapter: EventEmitter };
+    return origLoad.call(this, request, ...rest);
+};
+
+const dmZigbee = require('../lib/devicemgmt.js');
+
+class FakeAdapter extends EventEmitter {
+    constructor() {
+        super();
+        this.name = 'zigbee';
+        this.namespace = 'zigbee.0';
+        this.log = { debug() {}, info() {}, warn() {}, error() {} };
+        this.loads = 0;
+        this.devices = [];
+    }
+    async getDeviceInformation() {
+        this.loads++;
+        return { deviceObjects: this.devices };
+    }
+}
+
+const noopContext = { addDevice() {}, setTotalDevices() {}, complete() {} };
+
+// the cache lives in the module, not in the instance, so each test starts by dropping it
+function mkManager() {
+    const adapter = new FakeAdapter();
+    const dm = new dmZigbee(adapter);
+    dm.invalidateDeviceCache();
+    return { adapter, dm };
+}
+
+describe('device manager list cache', () => {
+    it('serves a second load from the cache', async () => {
+        const { adapter, dm } = mkManager();
+
+        await dm.loadDevices(noopContext);
+        await dm.loadDevices(noopContext);
+
+        assert.strictEqual(adapter.loads, 1);
+    });
+
+    it('would keep the tile of a departed device while the cache stands', async () => {
+        const { adapter, dm } = mkManager();
+        adapter.devices = [{ _id: 'zigbee.0.a085e3fffeb62fac', common: { name: 'Klo - Lüfter', type: 'device' }, native: { id: 'a085e3fffeb62fac' } }];
+
+        await dm.loadDevices(noopContext);
+        adapter.devices = []; // the device left the network, its object is gone
+        const listed = [];
+        await dm.loadDevices({ addDevice: (d) => listed.push(d), setTotalDevices() {}, complete() {} });
+
+        assert.strictEqual(listed.length, 1, 'this is the bug: the tile is still drawn from the cache');
+    });
+
+    it('reloads after the cache was dropped, so a departed device loses its tile', async () => {
+        const { adapter, dm } = mkManager();
+        adapter.devices = [{ _id: 'zigbee.0.a085e3fffeb62fac', common: { name: 'Klo - Lüfter', type: 'device' }, native: { id: 'a085e3fffeb62fac' } }];
+
+        await dm.loadDevices(noopContext);
+        adapter.devices = []; // the device left the network, its object is gone
+        dm.invalidateDeviceCache();
+        const listed = [];
+        await dm.loadDevices({ addDevice: (d) => listed.push(d), setTotalDevices() {}, complete() {} });
+
+        assert.strictEqual(adapter.loads, 2, 'the list was fetched again');
+        assert.deepStrictEqual(listed, [], 'the departed device has no tile any more');
+    });
+});


### PR DESCRIPTION
When a device leaves the network while the device manager is open, the adapter goes down with an unhandled rejection:

```
resolve_entity failed for {"kind":"ieee","key":"0xa085e3fffeb62fac", ...}
Device '0xa085e3fffeb62fac' left the network
Error Cannot read properties of undefined (reading 'device') building device info for undefined device
unhandled promise rejection: Cannot read properties of undefined (reading 'type')
    at Zigbee.fillInfo (main.js:1175)
    at Zigbee.getDeviceInformation (main.js:1273)
    at async Commands.getDevices (lib/commands.js:352)
Terminated (UNCAUGHT_EXCEPTION)
```

It is a race, not a pairing-only problem: in the same log a device left 48 seconds earlier without any harm, simply because no `getDevices` was running at that moment. Pairing just makes both happen at once.

### The change

`getDeviceInformation` builds its list from the ioBroker objects. `leaveDevice` deletes the object of a departing device without awaiting it, and the device is gone from the herdsman database first, so a call which started just before still sees the object and `resolveEntity` returns `undefined` for it. Such an object is no longer reported — the device is not part of the network, so it does not get a tile.

The same race reaches the function from the single device side, where `getObjectAsync` answers `null` for an object which is already gone, so that case is skipped as well. The loop variable holding the zigbee id no longer shadows the `id` parameter.

### Correction to the first version of this PR

The first version made `buildDeviceInfo` always return a complete block instead, and argued that such a device has to stay in the list to remain removable. That argument was wrong, and I should have verified it before writing it. An object without a device cannot persist in this adapter:

* `statescontroller.leaveDevice` deletes it on every leave event,
* `onReady` deletes whatever survived — `for (const id of await this.syncAllDeviceStates(false))` → `removing object for device ${id} - it is no longer in the zigbee database`.

So there is no orphan to keep reachable, and nothing is stranded by leaving these objects out of the list.

### What this changes beyond the crash

* If `resolveEntity` resolves nothing at all — herdsman not started — the list comes back empty instead of full of broken tiles. `Commands.getDevices` already refuses that state with *No active connection to Zigbee Hardware!*; the device manager path does not, and an empty list is the honest answer there.
* A device which is in the database but has lost its object is still reported: `appendDevicesWithoutObjects` adds it back from the client iterator, so nothing that is actually in the network can drop out of the list.
* `DeviceManagement.loadDevices` served its list from a 10 s cache, so the tile of a departed device outlived its object by up to ten seconds. The leave event now drops that cache, so the next load reflects the departure.

### Test

`test/deviceInfo.test.js` runs the real `Zigbee` class against a stubbed `adapter-core`, no hardware: the object of a departed device is not reported, devices which are still there and groups are, and both single device variants return an empty list instead of failing. RED 5/7 without the fix, with the exact `TypeError` above, GREEN 7/7 with it.

`test/deviceManagerCache.test.js` covers the cache the same way: a second load is served from the cache, a departed device keeps its tile while the cache stands, and dropping the cache makes that tile disappear.

Neither is wired into CI — the repo runs only `test:package`/`test:unit` — so they are runnable proofs, not CI guards, and the test commits can be dropped if you prefer. Run: `node --test test/deviceInfo.test.js test/deviceManagerCache.test.js`

`npm test` (56 + 1), `eslint` and `node --check` are green.
