### PR TITLE
Fix: force checkbox in the state cleanup dialog is never drawn

### DIFF
--- a/admin/tab_m.html
+++ b/admin/tab_m.html
@@ -1172,8 +1172,10 @@
             </div>
             <div class="modal-footer">
                 <div id="cforcediv" class="forcedelete">
-                    <input id="cforce" type="checkbox" class="value" />
-                    <label class="translate" for="cforce">Force removed states with custom configuration (history, upnp, etc.)</label>
+                    <label>
+                        <input id="cforce" type="checkbox" class="value" />
+                        <span class="translate" for="cforce">Force removed states with custom configuration (history, upnp, etc.)</span>
+                    </label>
                 </div>
                 <a name="yes" href="#!" class="modal-action modal-close waves-effect waves-green btn green translate">Yes</a>
                 <a href="#!" class="modal-action modal-close waves-effect waves-red btn-flat translate">Cancel</a>


### PR DESCRIPTION
The state cleanup can remove orphaned states that carry a custom configuration — history, upnp and the like — but only when the dialog's force checkbox is set. On the Zigbee tab that checkbox is never drawn: the dialog shows the label text and nothing else, so the option cannot be reached and those states stay behind for good.

Materialize hides the raw input and draws the visible box on the adjacent span. The cleanup dialog had the input as a sibling of the label with the text directly inside it, so nothing was drawn.

The delete dialog a few lines up in the same file already uses the working form, in the same `.forcedelete` container and the same modal footer:

```html
<!-- forcediv, renders -->
<label><input id="force" type="checkbox" class="value"/><span class="translate" for="force">…</span></label>

<!-- cforcediv, did not render -->
<input id="cforce" type="checkbox" class="value"/>
<label class="translate" for="cforce">…</label>
```

The cleanup dialog now matches it. Markup only — the id the handler reads stays `cforce`, so `$('#cforce').prop('checked')` is unaffected.

### Scope

Only `admin/tab_m.html`. The same sibling form appears in `admin/index_m.html` as well, but that file is the adapter config page rather than the tab, and the pattern demonstrably renders there — you added two more of them in `DevMgr et al` and they show up. I did not want to change something that works in a context I have not verified. Happy to unify them if you would rather have one form everywhere.

### Testing

Deployed to a running installation (admin uploaded, browser reloaded): the checkbox appears in the dialog, ticking it and confirming removes orphaned states that have history logging attached — before the change those states could not be removed at all. `eslint .` clean, package and unit tests pass.
