### PR TITLE
Fix: readReportConfig from the developer tab always fails

### DIFF
--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1412,6 +1412,8 @@ class ZigbeeController extends EventEmitter {
             let result;
             if (cmd === 'configReport') {
                 result = await endpoint.configureReporting(cid, zclData, cfg);
+            } else if (cmd === 'readReportConfig') {
+                result = await endpoint.readReportingConfig(cid, zclData, cfg);
             } else {
                 if (cmd === 'read' && !Array.isArray(zclData))
                     result = await endpoint[cmd](cid, Object.keys(zclData), cfg);

--- a/lib/zigbeecontroller.publish.test.js
+++ b/lib/zigbeecontroller.publish.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+// Run with: node --test lib/zigbeecontroller.publish.test.js
+// Covers the foundation branch of ZigbeeController.publish(): every global command the
+// developer tab can send has to reach the matching zigbee-herdsman Endpoint method.
+// Most global command names equal the method name, but two do not:
+//   configReport      -> endpoint.configureReporting()   (already mapped)
+//   readReportConfig  -> endpoint.readReportingConfig()
+
+const test = require('node:test');
+const assert = require('node:assert');
+const ZigbeeController = require('./zigbeecontroller.js');
+
+// Mirrors the real Endpoint surface: it has readReportingConfig, it has NO readReportConfig.
+function makeEndpoint() {
+    const calls = [];
+    const record = name => (...args) => {
+        calls.push({ name, args });
+        return { ok: name };
+    };
+    return {
+        calls,
+        read: record('read'),
+        write: record('write'),
+        report: record('report'),
+        configureReporting: record('configureReporting'),
+        readReportingConfig: record('readReportingConfig'),
+        writeStructured: record('writeStructured'),
+    };
+}
+
+function makeController(endpoint) {
+    return {
+        debugActive: false,
+        debug() {},
+        error(msg) {
+            throw new Error(`unexpected error path: ${msg}`);
+        },
+        devLabel: id => id,
+        resolveEntity: async () => ({ device: { ieeeAddr: '0x1' }, endpoint, mapped: { model: 'stub' } }),
+    };
+}
+
+async function publish(cmd, zclData) {
+    const endpoint = makeEndpoint();
+    const ctrl = makeController(endpoint);
+    let cbResult;
+    await ZigbeeController.prototype.publish.call(
+        ctrl, '0x1', 2820, cmd, zclData, null, 1, 'foundation',
+        (err, result) => { cbResult = { err, result }; },
+    );
+    return { endpoint, cbResult };
+}
+
+test('readReportConfig maps to endpoint.readReportingConfig', async () => {
+    const items = [{ attribute: 'activePower' }];
+    const { endpoint, cbResult } = await publish('readReportConfig', items);
+
+    assert.deepStrictEqual(
+        endpoint.calls.map(c => c.name),
+        ['readReportingConfig'],
+        'must call readReportingConfig - endpoint has no method named readReportConfig',
+    );
+    assert.strictEqual(endpoint.calls[0].args[0], 2820);
+    assert.deepStrictEqual(endpoint.calls[0].args[1], items, 'items are passed through untouched');
+    assert.strictEqual(endpoint.calls[0].args[2].disableDefaultResponse, true);
+    assert.deepStrictEqual(cbResult, { err: undefined, result: { ok: 'readReportingConfig' } });
+});
+
+test('configReport still maps to endpoint.configureReporting', async () => {
+    const { endpoint } = await publish('configReport', [{ attribute: 'activePower', minimumReportInterval: 10 }]);
+    assert.deepStrictEqual(endpoint.calls.map(c => c.name), ['configureReporting']);
+});
+
+test('read with an object payload is converted to an attribute name list', async () => {
+    const { endpoint } = await publish('read', { acPowerDivisor: 0, acPowerMultiplier: 0 });
+    assert.deepStrictEqual(endpoint.calls.map(c => c.name), ['read']);
+    assert.deepStrictEqual(endpoint.calls[0].args[1], ['acPowerDivisor', 'acPowerMultiplier']);
+});
+
+test('read with an array payload is passed through', async () => {
+    const { endpoint } = await publish('read', ['activePower']);
+    assert.deepStrictEqual(endpoint.calls[0].args[1], ['activePower']);
+});
+
+test('commands whose name already matches the method are dispatched unchanged', async () => {
+    for (const cmd of ['write', 'report', 'writeStructured']) {
+        const { endpoint } = await publish(cmd, [{ attrId: 1291 }]);
+        assert.deepStrictEqual(endpoint.calls.map(c => c.name), [cmd], `${cmd} must dispatch to endpoint.${cmd}`);
+    }
+});


### PR DESCRIPTION
In the developer tab, picking `foundation` fills the command dropdown from `Zcl.Foundation`, so all 23 global commands are offered. Choosing `readReportConfig` never works — it fails with `endpoint[cmd] is not a function` and the adapter logs `SendToZigbee failed!`.

The reason is in the foundation branch of `publish()`. Commands are dispatched by their ZCL name:

```js
if (cmd === 'configReport') {
    result = await endpoint.configureReporting(cid, zclData, cfg);
} else {
    if (cmd === 'read' && !Array.isArray(zclData))
        result = await endpoint[cmd](cid, Object.keys(zclData), cfg);
    else
        result = await endpoint[cmd](cid, zclData, cfg);
}
```

That works as long as the ZCL command name equals the herdsman method name. `configReport` is already special-cased because it does not — the method is `configureReporting`. `readReportConfig` has exactly the same problem, the method is `readReportingConfig`, but it falls into the generic branch.

### All 23 global commands

Checked against `zigbee-herdsman` 10.7.0 (the version the lockfile resolves for the current `^10.6.3`); the result is identical on 10.6.2 and 10.5.0.

| | commands | state |
|---|---|---|
| name matches the method | `read`, `write`, `report`, `writeStructured` | work today |
| name differs | `configReport` → `configureReporting` | already mapped |
| name differs | `readReportConfig` → `readReportingConfig` | **fixed here** |
| name differs | `readRsp` → `readResponse`, `writeRsp` → `writeResponse` | see below |
| no method in herdsman | the remaining 15 | out of reach either way |

### Why `readRsp` and `writeRsp` are not part of this

They are name mismatches too, but they cannot be fixed by mapping a name:

```js
async readResponse(clusterKey, transactionSequenceNumber, attributes, options)
async writeResponse(clusterKey, transactionSequenceNumber, attributes, options)
```

The second parameter is the transaction sequence number, and the foundation branch only ever passes `(cid, zclData, cfg)`. `publish()` does receive a `zclSeqNum`, but it is used solely in the `functionalResp` branch, where the response-shaped call already lives. Routing the two response commands correctly means giving them their own call shape, not renaming a method — a separate change, and arguably they belong next to `commandResponse` rather than in the request path.

The 15 commands without any herdsman method still surface as `endpoint[cmd] is not a function`. I left that alone deliberately: there is no correct method to route them to, so turning it into a friendlier message would be a decision about how the developer tab should behave, which is yours to make.

### What this unlocks

`readReportConfig` is the only way to see the reporting configuration a device is actually holding. `configuredReportings` in the database is the adapter's cache of what a device once acknowledged — a device that dropped or never applied its reporting table looks identical there. With the fix the tab answers that directly.

On seven LEDVANCE plugs here the readout showed the reporting tables are intact and match what the converter configured (`min 10 s`, `max 65000 s`, `change 50` for `activePower` at `acPowerDivisor 10`, i.e. 5 W). That is a converter-side question and not something this PR touches — it is just what made the missing command noticeable.

### Scope

One line in `lib/zigbeecontroller.js`, in the same `if/else` that already handles `configReport`. No behaviour change for any command that works today.

### Testing

`lib/zigbeecontroller.publish.test.js` is added as a dependency-free `node:test`, run with:

```
node --test lib/zigbeecontroller.publish.test.js
```

It calls the real `publish()` against a stub endpoint that mirrors the herdsman surface — it has `readReportingConfig` and, like the real one, no `readReportConfig`. Five cases: the new mapping, `configReport` still reaching `configureReporting`, `read` with an object payload being converted to a name list, `read` with an array passed through, and `write`/`report`/`writeStructured` dispatching unchanged. Against the unpatched file the first case fails with `endpoint[cmd] is not a function` and the other four stay green, so it isolates this defect.

Note this is an attached proof, not a CI guard — the workflow runs `test:package`, `test:unit` and `test:integration`, and `test:js` does not work in this repo, so nothing picks up `lib/*.test.js`. I did not want to change your test setup for this.

`eslint .` is clean (the three remaining warnings are pre-existing, in `admin/admin.js`), `npm test` passes with 57 tests.

Also verified on a running installation — adapter 3.4.11 from npm, where this block is character-identical to master, with the same one-line change applied. Across seven devices `readReportConfig` now returns the per-attribute configuration where it previously threw, for example:

```
{"msg":[{"status":0,"direction":0,"attrId":1291,"dataType":41,
         "minRepIntval":10,"maxRepIntval":65000,"repChange":50}],"statusCode":0}
```

Two things worth knowing for anyone using it: the payload is `[{"attribute":"activePower"}]` rather than `{direction, attrId}` — `readReportingConfig` builds the ZCL payload itself — and more than three or four attributes per frame runs into `Delivery failed`, which is why `setupAttributes` chunks in groups of four.

