### PR TITLE
Fix: error replies from sendTo handlers arrive as [object Object]

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -451,6 +451,12 @@ class Commands {
     async getChannels(from, command, message, callback) {
         if (this.zbController && this.zbController.herdsmanStarted) {
             const result = await this.zbController.getChannelsEnergy();
+            // a failed scan hands back an Error object. It has no enumerable properties, so
+            // JSON.stringify() reduces it to {} - in the debug line below and, since the reply
+            // is serialised the same way, as [object Object] in the admin dialog.
+            if (result.error) {
+                result.error = result.error.message || String(result.error);
+            }
             this.debug(`getChannels result: ${JSON.stringify(result)}`);
             this.adapter.sendTo(from, command, result, callback);
         } else {

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -397,8 +397,11 @@ class Groups {
             }
             this.syncGroups(false,GroupsToSync);
         } catch (e) {
-            this.warn('caught error ' + JSON.stringify(e) + ' in updateGroupMembership');
-            this.adapter.sendTo(from, command, {error: e}, callback);
+            // JSON.stringify() on an Error yields {} - report message and stack instead, and hand
+            // the caller the text: the reply is serialised too and would arrive as [object Object].
+            const errorText = e?.message || String(e);
+            this.warn(`caught error ${errorText} in updateGroupMembership${e?.stack ? ` ${e.stack}` : ''}`);
+            this.adapter.sendTo(from, command, {error: errorText}, callback);
             return;
         }
         //await this.renameGroup(from, command, { name: undefined, id: message.id});

--- a/main.js
+++ b/main.js
@@ -131,6 +131,12 @@ class Zigbee extends adapterCore.Adapter {
                         rv.error = e;
                     }
 
+                    // both sendPayload and the catch above can put an Error object here. It has no
+                    // enumerable properties, so the serialised reply would arrive as [object Object].
+                    if (rv.error) {
+                        rv.error = rv.error.message || String(rv.error);
+                    }
+
                     this.sendTo(obj.from, obj.command, rv, obj.callback);
                     break;
                 }


### PR DESCRIPTION
Pressing **Scan Channels** on a coordinator where the scan cannot work gives you an error dialog that says exactly this:

```
[object Object]
```

The log has the full stack, but the dialog — the thing the user is actually looking at — has nothing. The same happens for a `SendToDevice` message and for group membership changes.

### Why

Replies handed to `adapter.sendTo()` are serialised on their way to the caller (`js-controller` 7.2.2: `_sendTo` → `states.pushMessage` → `client.publish(…, JSON.stringify(fullMessage))`). `Error` has no enumerable own properties, so

```js
JSON.stringify({ error: new Error('timed out after 15000ms') })   // -> {"error":{}}
```

The admin UI passes that empty object to `showMessage()`, which renders it with `$(…).html(message)` — hence `[object Object]`.

### What this changes

Reworked per review: the producing functions keep their return type. The check happens where the value is read — an `Error` is reported with `.message` (and `.stack` in the log line), a string is used directly.

| read site | reads |
|---|---|
| `lib/commands.js` `getChannels()` | the result of `getChannelsEnergy()` |
| `main.js` `SendToDevice` | the result of `sendPayload()` and its own `catch` |
| `lib/groups.js` `updateGroupMembership()` | the caught error |

`syncGroups()` is called without `await`, as before.

### The reply, not only the log

At each read site the text also goes into the reply, because the admin cannot do this check itself: the reply is serialised on the way out, so what arrives in `admin.js` is `{}` — there is no `.message` or `.stack` left to inspect. If you would rather have the reply keep the raw value and only the log lines fixed, say so and I will drop that half.

**No log line is added.** `getChannelsEnergy()` already logs `error.stack` and `publishPayload()` already logs `error.code` and `error.stack`. `groups.js` was the one place that logged `JSON.stringify(e)`, printing `{}` for the same reason, and now reports message and stack instead.

An `Error` whose message is empty falls back to `String(error)`, so the reply always carries a non-empty text — the admin dialogs test the value for truthiness before showing it.

### Swept, left alone

`admin/admin.js:1038` calls `msg.error.includes('ENOENT')` on the `delNvBackup` reply, which throws if the value is not a string. That one belongs to #2956.

`eslint .` is clean — the 3 remaining warnings are pre-existing, in `admin/adapter-settings.js` and `admin/admin.js`.
