### PR TITLE
Fix: a failed herdsman restart in delNvBackup leaves the admin dialog hanging

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -214,38 +214,37 @@ class Commands {
 
     async delNvBackup(from, command, msg, callback) {
         try {
+            const rv={};
             if (this.zbController)
             {
                 // stop the herdsman if needed
                 const wasRunning = this.zbController.herdsmanStarted;
                 if (wasRunning) await this.zbController.stop();
                 const name = this.zbController.herdsman.adapter.backupPath;
-                fs.unlink(name, async (err) => {
-                    const rv={};
-                    if (err) {
-                        this.error(`Unable to remove ${name}: ${err}`);
-                        rv.error = `Unable to remove ${name}: ${err}`;
-                    }
-                    // start the herdsman again if it  was stopped before
-                    if (wasRunning) await this.zbController.start();
-                    this.adapter.sendTo(from, command, rv, callback)
-                });
+                // a failed removal is not fatal - the herdsman still has to come back up
+                try {
+                    fs.unlinkSync(name);
+                } catch (err) {
+                    this.error(`Unable to remove ${name}: ${err}`);
+                    rv.error = `Unable to remove ${name}: ${err}`;
+                }
+                // start the herdsman again if it  was stopped before
+                if (wasRunning) await this.zbController.start();
             }
             else {
                 const zo = this.adapter.getZigbeeOptions();
                 const name = path.join(zo.dbDir, zo.backupPath);
-                fs.unlink(name, async (err) => {
-                    const rv={};
-                    if (err) {
-                        this.error(`Unable to remove ${name}: ${err}`);
-                        rv.error = `Unable to remove ${name}: ${err}`;
-                    }
-                    // start the herdsman again if it  was stopped before
-                    this.adapter.sendTo(from, command, rv, callback)
-                });
+                try {
+                    fs.unlinkSync(name);
+                } catch (err) {
+                    this.error(`Unable to remove ${name}: ${err}`);
+                    rv.error = `Unable to remove ${name}: ${err}`;
+                }
             }
+            this.adapter.sendTo(from, command, rv, callback)
         } catch (error) {
-            this.adapter.sendTo(from, command, {error: error.message}, callback)
+            // zigbeecontroller.start() rejects with a plain string, so .message is undefined there
+            this.adapter.sendTo(from, command, {error: error?.message || String(error)}, callback)
             this.error(error);
         }
     }


### PR DESCRIPTION
Deleting the NV backup from the admin UI can leave the dialog waiting forever, with nothing in the log to explain it.

### Why

`delNvBackup()` stops the herdsman, deletes the file and starts it again. The restart sits inside the `fs.unlink` callback:

```js
try {
    if (wasRunning) await this.zbController.stop();          // inside the try — covered
    fs.unlink(name, async (err) => {
        …
        if (wasRunning) await this.zbController.start();     // inside the callback — not covered
        this.adapter.sendTo(from, command, rv, callback)
    });
} catch (error) {
    this.adapter.sendTo(from, command, {error: error.message}, callback)
}
```

The callback runs after the `try` block has already been left, so the `catch` cannot see it. `zbController.start()` does reject — `zigbeecontroller.js:283` throws `'Error herdsman start'` when zigbee-herdsman fails to come up. The rejection is then unhandled *and* the `sendTo()` on the next line never runs, so the dialog waits for a reply that never comes.

### What this changes

Reworked per review: both `fs.unlink` callbacks are gone. The removal is now `fs.unlinkSync`, as `readNvBackup()` a few lines above already does, and the function runs in one linear flow.

With the callback gone the existing `catch` covers the restart on its own. The result is a reply count of exactly one on **every** path:

| path | reply |
|---|---|
| success | `{}` |
| removal failed | `{error: 'Unable to remove …'}` |
| restart failed | `{error: 'Error herdsman start'}` |
| stop failed | `{error: …}` |

Measured against `master` for the restart-failure case: 0 replies and an unhandled rejection before, 1 reply after.

The failed removal keeps an inner `try`/`catch`, so it stays non-fatal exactly as the callback had it — without that, an already-missing backup file would abort the function and leave the herdsman stopped.

`start()` rejects with the plain string `'Error herdsman start'` rather than an `Error`, so the outer catch reads the value before passing it on. `error.message` alone would have yielded `{error: undefined}`, which the admin treats as falsy — no hanging dialog, but no message either. Same read-site handling as #2955.

### On the ENOENT branch in admin.js

I flagged `admin/admin.js:1038` (`msg.error.includes('ENOENT')`) on #2955 as belonging here. Having checked this path: it cannot break. `delNvBackup()` is the only sender of this reply, every `error` value on it is a string, and the no-error case leaves the field undefined so the surrounding `if (msg.error)` never lets `.includes` run. No change needed.

`eslint .` is clean — the 3 remaining warnings are pre-existing, in `admin/adapter-settings.js` and `admin/admin.js`.
