### PR TITLE
Fix: hasZdoMessageOverhead is hardcoded, corrupting the channel-scan request on ember/ezsp/deconz

### DIFF
--- a/lib/zdo-message-overhead.test.js
+++ b/lib/zdo-message-overhead.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Run with: node --test lib/zdo-message-overhead.test.js
+//
+// Zdo.Buffalo.buildRequest() takes hasZdoMessageOverhead as its first argument. The flag
+// decides whether a leading byte is reserved for the transaction sequence number, and it is
+// coordinator specific: false on zstack/zigate/zboss, true on ember/ezsp/deconz.
+//
+// Adapters that need the byte write the message tag into payload[0] before sending. If the
+// byte was not reserved, that write lands on the first byte of the channel mask instead.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const ZDO = require('zigbee-herdsman/dist/zspec/zdo');
+const ZigbeeController = require('./zigbeecontroller.js');
+
+const CHANNELS_11_TO_26_MASK = 0x07fff800;
+const MESSAGE_TAG = 0x42;
+
+// Captures the payload getChannelsEnergy() hands to the adapter.
+function makeController(hasZdoMessageOverhead) {
+    const stub = Object.create(ZigbeeController.prototype);
+    stub.debugActive = false;
+    stub.debug = () => {};
+    stub.error = () => {};
+    stub.sendError = () => {};
+    stub.sent = null;
+    stub.herdsman = {
+        adapter: {
+            hasZdoMessageOverhead,
+            sendZdo: async (_ieee, _nwk, _cluster, payload) => {
+                stub.sent = Buffer.from(payload);
+                return [{}, { entryList: [] }];
+            },
+        },
+    };
+    return stub;
+}
+
+// What ember/ezsp do to the payload right before sending it.
+function applyMessageTag(payload) {
+    const copy = Buffer.from(payload);
+    copy[0] = MESSAGE_TAG;
+    return copy;
+}
+
+test('the overhead flag is taken from the adapter, not hardcoded', async () => {
+    const ember = makeController(true);
+    await ember.getChannelsEnergy();
+    const zstack = makeController(false);
+    await zstack.getChannelsEnergy();
+
+    assert.strictEqual(
+        ember.sent.length,
+        zstack.sent.length + 1,
+        'a coordinator requiring the overhead has to get one byte more',
+    );
+});
+
+test('on a coordinator with overhead the channel mask survives the message tag', async () => {
+    const controller = makeController(true);
+    await controller.getChannelsEnergy();
+
+    const maskOffset = 1; // the reserved byte comes first
+    assert.strictEqual(controller.sent.readUInt32LE(maskOffset), CHANNELS_11_TO_26_MASK);
+    assert.strictEqual(
+        applyMessageTag(controller.sent).readUInt32LE(maskOffset),
+        CHANNELS_11_TO_26_MASK,
+        'the tag must not reach the channel mask',
+    );
+});
+
+test('on a coordinator without overhead the payload is unchanged', async () => {
+    const controller = makeController(false);
+    await controller.getChannelsEnergy();
+
+    const expected = ZDO.Buffalo.buildRequest(
+        false,
+        ZDO.ClusterId.NWK_UPDATE_REQUEST,
+        [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+        0x05,
+        1,
+        0,
+        undefined,
+    );
+    assert.deepStrictEqual(controller.sent, Buffer.from(expected), 'zstack/zigate/zboss keep the current payload');
+    assert.strictEqual(controller.sent.readUInt32LE(0), CHANNELS_11_TO_26_MASK);
+});

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -2194,7 +2194,9 @@ class ZigbeeController extends EventEmitter {
         const result = {};
         try
         {
-            const payload = ZDO.Buffalo.buildRequest(false, clusterId, [11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26], 0x05, 1, 0, undefined);
+            // the overhead flag is coordinator specific - false on zstack/zigate/zboss, true on
+            // ember/ezsp/deconz - so it has to be taken from the adapter instead of hardcoded
+            const payload = ZDO.Buffalo.buildRequest(this.herdsman.adapter.hasZdoMessageOverhead, clusterId, [11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26], 0x05, 1, 0, undefined);
             const scanresult = await this.herdsman.adapter.sendZdo(0x0, 0x0, clusterId , payload, false);
             if (this.debugActive) this.debug(`scanresult is  ${JSON.stringify(scanresult)}`)
             result.energyvalues = scanresult[1].entryList;


### PR DESCRIPTION
`getChannelsEnergy()` builds its ZDO request like this:

```js
const payload = ZDO.Buffalo.buildRequest(false, clusterId, [11..26], 0x05, 1, 0, undefined);
```

The first argument is `hasZdoMessageOverhead`, and it is not a constant — zigbee-herdsman sets it per driver:

| value | drivers |
|---|---|
| `false` | zstack, zigate, zboss |
| `true` | ember, ezsp, deconz, zoh — and the `Adapter` base class |

The adapter hardcodes the zstack value. Of the five coordinator types `admin/index_m.html` offers, three get the wrong one: ember, ezsp and deconz.

### What the wrong value does

The flag decides whether `buildRequest` reserves a leading byte for the transaction sequence number. Coordinators that need it write the message tag into `payload[0]` before sending — and without the reserved byte, that write lands on the first byte of the channel mask:

```
hasZdoMessageOverhead=false     00f8ff070501       -- tag 0x42 -->  42f8ff070501
                                mask 0x07fff800                     0x07fff842

hasZdoMessageOverhead=true      0000f8ff070501     -- tag 0x42 -->  4200f8ff070501
                                mask 0x07fff800                     0x07fff800
```

`0x42` above is just an example. The tag is `nextZDORequestSequence()`, a counter masked with `APPLICATION_ZDO_SEQUENCE_MASK` (`0x7f`), so it rotates per request: 127 of its 128 possible values corrupt the mask, and on `0x00` the request happens to come out correct. The scan therefore asks for a different, mostly nonexistent set of channels on nearly every call.

### What it changes in practice

Being straight about the effect, because it differs per coordinator:

- **ember** — the one this was found on: the scan does not complete anyway. The `NWK_UPDATE_REQUEST` runs into the 15 s timeout, which is a separate problem and not fixable here. So on ember this patch changes nothing you can observe.
- **ezsp, deconz** — same wrong flag, but I have no such coordinator to test with, so I cannot say whether the scan completes there. If it does, it has been scanning a corrupted channel set all along.
- **zstack, zigate, zboss** — the flag is already correct for them; the payload stays **byte-identical**, so nothing can regress.

What speaks for the change regardless of where it shows:

- the value is provably wrong, and reading it from the adapter is what zigbee-herdsman itself does everywhere;
- it cannot regress the coordinators where the scan works today, since their payload does not change;
- it becomes load-bearing the moment the timeout is addressed. At that point a malformed channel mask would be the next bug, on a code path nobody would think to re-check.

### Why the value belongs to the adapter object

zigbee-herdsman never hardcodes it. Every driver passes `this.hasZdoMessageOverhead` at its own `buildRequest` call sites, and — most directly comparable — `Controller.changeChannel()` builds the **same** `NWK_UPDATE_REQUEST` cluster with `this.adapter.hasZdoMessageOverhead`.

`this.herdsman.adapter` is already the object used on the next line for `sendZdo()`; the change dereferences it one line earlier, inside the same `try`, so an undefined `herdsman` still lands in the same `catch` as before. `hasZdoMessageOverhead` is part of the public `Adapter` surface.

This is the only place in the adapter that builds a ZDO request itself — checked with three separate search patterns (`buildRequest`, any `ZDO.`/`Zdo.` usage, and `hasZdoMessageOverhead`, which appears nowhere else in the tree) — so it is also the only place that has to read the value.

### Testing

`lib/zdo-message-overhead.test.js` is added as a dependency-free `node:test`:

```
node --test lib/zdo-message-overhead.test.js
```

Three cases, each driving the real `getChannelsEnergy()` against a stubbed adapter and capturing the payload handed to `sendZdo()`: the flag being taken from the adapter at all, the channel mask surviving the message tag when the overhead byte is present, and the payload staying byte-identical when it is not. Against `master` the first two fail and the third — the unchanged-behaviour control — stays green.

As in #2954, this is attached proof rather than a CI guard: the workflow runs `test:package`, `test:unit` and `test:integration`, and nothing picks up `lib/*.test.js`.

Independent of #2955, which touches the same file: the changed hunks do not overlap and a test merge of both is clean.

`eslint .` is clean (the 3 remaining warnings are pre-existing, in `admin/adapter-settings.js` and `admin/admin.js`), `npm test` passes with 56 + 1 tests.
