### PR TITLE
Fix device query for devices with device dependent exposes

### DIFF
--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1953,7 +1953,11 @@ class ZigbeeController extends EventEmitter {
         const source = mappedModel.toZigbee.filter((fz) => fz.hasOwnProperty('convertGet'));
         let read = 0;
         let attempt = 0;
-        const targets = this.recursiveCollectStates(mappedModel.exposes ?? []);
+        // exposes is either an Expose[] or a DefinitionExposesFunction - zigbee-herdsman-converters
+        // returns the latter as soon as one modern extend contributes device dependent exposes.
+        let definitionExposes = mappedModel.exposes;
+        if (typeof definitionExposes === 'function') definitionExposes = definitionExposes(entity.device, {});
+        const targets = this.recursiveCollectStates(Array.isArray(definitionExposes) ? definitionExposes : []);
         for (const target of targets) {
             let converter = undefined;
 
@@ -1967,7 +1971,7 @@ class ZigbeeController extends EventEmitter {
                     converter = candidate;
                 }
                 // the last keyed converter is used.
-                if (candidate.key.includes(target.key))
+                if (candidate.key?.includes(target.key))
                     converter = candidate;
             }
             if (target.epName) meta.endpoint_name = target.epName;
@@ -2015,7 +2019,7 @@ class ZigbeeController extends EventEmitter {
             await this.doDeviceQuery(deviceId, debugID, elevated);
         }
         catch (e) {
-            this.warn('error in doDeviceQuery')
+            this.warn(`error in doDeviceQuery for '${this.devLabel(deviceId)}': ${e && e.message ? e.message : e}`);
         }
         const idx = this.deviceQueryActive.indexOf(deviceId)
         if (idx > -1)


### PR DESCRIPTION
Pressing "device query" on an Aqara FP300 presence sensor produces a single log line with no device and no reason:

```
zigbee.0 (15332) error in doDeviceQuery
```

The startup sweep is louder about the same thing — 12 devices at once, this time with the message:

```
DeviceAvailability:device query for 'Küche - Herd (0x781c9dfffef17d25)' failed: exposes is not iterable
```

On my network 19 of 51 devices are affected: Aqara FP300, Shelly 1PM Mini / 2PM / Presence, Tuya TS011F, CS-201Z. They keep reporting normally — only querying them fails, and it fails before a single frame is sent.

## Cause

`exposes` is either an `Expose[]` **or** a `DefinitionExposesFunction`. zigbee-herdsman-converters returns the latter as soon as one modern extend contributes device dependent exposes (`processExtensions`, index.ts: *"In case there is a function in allExposes, return a function, otherwise just an array"*).

`doDeviceQuery` passes it straight into `recursiveCollectStates`, where `for...of` throws. The existing `?? []` only covers `null`/`undefined`, not a function:

```js
const targets = this.recursiveCollectStates(mappedModel.exposes ?? []);
```

This surfaced with the device-ping rework in 65d3dbf9: before that, the loop iterated `mappedModel.toZigbee`, which is always an array. v3.4.11 is not affected.

The adapter handles both shapes everywhere else, and most of those sites test for the function first: `exposes.js:381`/`:388`, `models.js:492`/`:498` and `main.js:1115` branch on `typeof`, only `statescontroller.js:1362` branches on `Array.isArray`. This call site now follows the former, with a trailing array check so a definition returning something unexpected cannot throw here either. I put the guard at the call site rather than inside `recursiveCollectStates`, because the recursive calls pass `expose.features` (always an array) and the device needed to resolve the function is only available here.

## Also in this commit

- **`candidate.key?.includes(...)`** — line 1966 explicitly anticipates keyless converters, line 1970 then dereferenced `candidate.key` unguarded. It cannot fire today because the exposes throw happens first; fixing only the throw would have moved the crash here for anyone whose device has such a converter. None of my 51 devices do, so this is prevention, not a repro.
- **Keeping the error text in `deviceQuery`** — `catch (e) { this.warn('error in doDeviceQuery') }` discarded both device and reason, which is why the button failure above was undiagnosable. Now uses the house pattern `e && e.message ? e.message : e` plus `devLabel(deviceId)`.

## Verification

I cut the real block out of `lib/zigbeecontroller.js` — once from `master`, once from the first version of this branch, once from the reworked one — and ran all three against the bundled zigbee-herdsman-converters 26.86.0 and my live `shepherd.db`. All 51 devices resolve to a definition; 19 of them carry a `DefinitionExposesFunction`:

| | fail | pass |
|---|---|---|
| `master` | **19** | 32 |
| this branch | **0** | 51 |

Those 19 now collect 12–37 queryable states each. For the 32 that already worked the target set is identical before and after, and the reworked version returns the same target set as the first one for all 51 — the change is in the shape of the check, not in what it collects. `node --check` and `eslint` are clean.

Coordinator here is ember (SLZB-MR3), but nothing in this path is coordinator specific — it fails before any radio traffic.
