### PR TITLE
fix: spurious 'resolve_entity failed' error on every device leave

### DIFF
--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1085,21 +1085,20 @@ class ZigbeeController extends EventEmitter {
     async handleDeviceLeave(message) {
         try {
             if (this.debugActive) this.debug('handleDeviceLeave', message);
-            const entity = await this.resolveEntity(message.device || message.ieeeAddr);
-            const friendlyName = entity ? entity.name : message.ieeeAddr;
-            const displayName = entity
-                ? utils.deviceDisplayName(entity.device?.ieeeAddr ?? message.ieeeAddr, this.adapter.stController.verifyDeviceName(entity.id, entity.mapped?.model, entity.mapped?.model))
-                : message.ieeeAddr;
-            if (this.adapter.stController.checkDebugDevice(friendlyName)) {
+            // zigbee-herdsman removes the device from its database before emitting
+            // deviceLeave, so resolving the entity here can never succeed.
+            // Use the cached device name instead of a lookup that is guaranteed to fail.
+            const displayName = this.devLabel(message.ieeeAddr);
+            if (this.adapter.stController.checkDebugDevice(message.ieeeAddr)) {
                 this.emit('device_debug', {ID: Date.now(), data: {flag:'dl', states:[{id: '--', value:'--', payload:message}], IO:true},message:`Device '${displayName}' has left the network`});
             }
             else
                 this.warn(`Device '${displayName}' left the network`);
-            this.emit('leave', message.ieeeAddr, entity?.mapped?.model);
+            this.emit('leave', message.ieeeAddr);
             // Call extensions
             this.callExtensionMethod(
                 'onDeviceLeave',
-                [message, entity],
+                [message, undefined],
             );
         } catch (error) {
             this.sendError(error);


### PR DESCRIPTION
## What the user sees

Whenever any device leaves the network (re-pairing, removing a battery device, a sensor resetting), the log shows a red error line that looks like an adapter failure:

```
error: resolve_entity failed for {"kind":"ieee","key":"0x...","message":"success"} called from process.processTicksAndRejections
warn:  Device '0x...' left the network
```

The error appears on every single leave, and the leave warning is the only device-related log line that never shows the device name — just the bare address.

## Why it happens

zigbee-herdsman removes the departing device from its database *before* it emits `deviceLeave` (controller.js, `removeFromDatabase()` directly before `selfAndDeviceEmit(...)`). By the time `handleDeviceLeave` runs, `resolveEntity()` is guaranteed to find nothing — the lookup fails on every leave and logs the error line from `resolveEntity`. The `entity ? ... : message.ieeeAddr` fallbacks in the handler therefore always take the bare-address branch.

## Fix

Drop the lookup that cannot succeed and resolve the display name from the state controller's name cache (`devLabel`) instead — the cache is still populated at this point, so the warning now reads `Device 'Kitchen sensor (0x...)' left the network`. The debug-device match keeps receiving the ieee address (it effectively always did, since the entity was always undefined), and the `leave` event consumers are unchanged (the model argument was always undefined for the same reason).

After this change, the `resolve_entity failed` diagnostic only fires for genuinely unexpected lookups — which is what it is there for.

## Verified

- Before/after run against the real module with a stubbed adapter: on master, a simulated leave logs the error line plus the bare-address warning; with the fix, no error line, the warning shows `name (ieee)`, and the `leave` event / extension dispatch behave identically (8/8 assertions).
- `npm run lint` and `node --check` clean.

## Note

`insertedDeviceLeave` (a few lines above) contains the same dead lookup, gated behind the `ignore_device_delete` option — which structurally cannot take effect on this event path for the same reason: the device is already removed (and the database file already rewritten) before any listener runs. I deliberately left that untouched — making the option functional again would be a behaviour change and needs a model lookup that survives the removal, so that one is yours to call. Happy to pick it up separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
