### PR TITLE
fix: availability check of a departed device runs forever

### DIFF
--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -188,6 +188,11 @@ class DeviceAvailability extends BaseExtension {
         delete this.timers[device.ieeeAddr];
     }
 
+    onDeviceLeave(data, entity) {
+        // stop the recurring availability check of a device that left the network
+        this.onDeviceRemove(entity?.device ?? data);
+    }
+
     async handleIntervalPingable(device, entity) {
         if (!this.isStarted) return;
         if (!this.active_ping) {

--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -279,7 +279,12 @@ class DeviceAvailability extends BaseExtension {
     async handleIntervalNotPingable(device) {
         if (!this.isStarted) return;
         const entity = await this.zigbee.resolveEntity(device.ieeeAddr);
-        if (!entity || !device.lastSeen) {
+        if (!entity) {
+            // device does not exist anymore (left or was removed) - stop its recurring check
+            this.onDeviceRemove(device);
+            return;
+        }
+        if (!device.lastSeen) {
             return;
         }
 


### PR DESCRIPTION
## What the user sees

After a device leaves the network (re-pairing, removal, a sensor resetting), the log shows this error line again and again — every 5 minutes, indefinitely, until the adapter restarts or the device is paired again:

```
error: resolve_entity failed for {"kind":"ieee","key":"0x...","message":"success"} called from async
```

Observed live: a battery sensor left during re-pairing at 16:29; the line then appeared at 16:30, 16:35, 16:40 and 16:45, exactly 300 s apart.

## Why it happens

At startup, DeviceAvailability creates a recurring check per non-pingable (battery) device (`onZigbeeStarted`, `setInterval` into `this.timers`). It is the only extension that holds recurring timers — and it had no `onDeviceLeave`. When a device leaves, zigbee-herdsman removes it from its database before emitting the event, so nothing stops the interval: every round, `handleIntervalNotPingable` fails to resolve the departed device (logging the error line) and silently returns, leaving the interval armed.

The pingable path already handles this case — a failed lookup logs "device is not known anymore" and its timeout chain simply ends. The non-pingable path uses a recurring interval, so it needs explicit cleanup.

## Fix

- **Commit 1:** add the `onDeviceLeave` wiring, mirroring what DeviceConfigure already has — the departing device's timer is cleared right on the leave event.
- **Commit 2** (separable): if a check round finds that its device no longer exists, stop that recurring check — symmetry with the pingable path. This also covers departures the leave event cannot reach: deleting an already-departed device through the admin skips the `onDeviceRemove` dispatch entirely, because the device cannot be resolved anymore at that point (`deleteZigbeeDevice` → `remove()` bails out before the dispatch).

## Verified

- Before/after run against the real module with stubs (8/8 assertions): on master, the timer survives both the leave and a failed check round; with the fix, the leave clears it, a failed round clears an orphaned one, and a device that still resolves keeps its check untouched.
- `npm run lint` and `node --check` clean.

## Note

Two adjacent observations, deliberately not part of this PR: `startNotPingable()` has no caller anywhere in the tree, and consequently a battery device paired *after* adapter startup gets no recurring availability check until the next restart. Wiring that up needs an `isPingable` filter and a guard against double-creation at startup, so it felt like its own change — happy to pick it up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
