### PR TITLE
fix: device configuration keeps running against a device that left the network

### DIFF
--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -133,6 +133,8 @@ class DeviceConfigure extends BaseExtension {
             if (this.configureOnMessageAttempts && this.configureOnMessageAttempts.hasOwnProperty(device.ieeeAddr)) {
                 delete this.configureOnMessageAttempts[device.ieeeAddr];
             }
+
+            this.deviceConfigureQueue = this.deviceConfigureQueue.filter((item) => item.id !== device.ieeeAddr);
         } catch (error) {
             this.sendError(error);
             this.error(`Failed to DeviceConfigure.onDeviceRemove (${error && error.message ? error.message : 'no error message'})`);
@@ -202,6 +204,12 @@ class DeviceConfigure extends BaseExtension {
             }
         } catch (error) {
             this.configuring.delete(device.ieeeAddr);
+            if (device.isDeleted) {
+                // the device left the network while it was being configured
+                delete this.configureOnMessageAttempts[device.ieeeAddr];
+                this.debug(`Configuration of '${this.devLabel(device.ieeeAddr, mappedDevice?.model)}' aborted - the device left the network`);
+                return '';
+            }
             // check for unsupported messages
             const errmsg = error.message ?? 'no message';
             const hasmatch = errmsg.match(/(\d+)ms/gm)


### PR DESCRIPTION
## What the user sees

When a device leaves the network at the wrong moment — e.g. a battery sensor that resets or re-pairs while it is being set up — the log shows a warning that looks like a broken device or a broken definition:

```
warn: DeviceConfigure:'SBHT-203C (0x...)' Failed to configure. --> Cannot read properties of undefined (reading 'manufacturerID')
```

Observed live during a re-pairing loop of a Shelly BLU H&T ZB: the device left at 16:29:06, the warning followed at 16:29:15 — configuration ran against a device that was already gone.

## Why it happens

`onDeviceLeave` clears the in-progress marker and the configure-on-message bookkeeping, but not the `deviceConfigureQueue`: a device parked there is still configured after it has left (the queue worker fires every 5 s). The run then dies inside zigbee-herdsman — every cluster access re-reads the device from the database (`endpoint.getDevice()`), which no longer holds it, and the next line dereferences `device.manufacturerID`.

An in-flight configure at leave time hits the same wall through its next cluster access.

## Fix

Two parts that belong together:

- `onDeviceRemove` also drops the device's entry from `deviceConfigureQueue` — mirroring the two cleanups the function already does. Nothing is lost: if the device rejoins, the `deviceJoined`/interview-successful path re-queues it with priority anyway.
- `doConfigure`'s error path recognises the case: if the device is gone (`device.isDeleted`), drop the configure-on-message bookkeeping and log a debug line instead of the misleading warning. This also keeps the error handler itself safe on a removed device: without it, the `UNSUPPORTED_ATTRIBUTE` branch would call `device.save()` on the removed instance — whose database write throws with no caller awaiting (unhandled rejection) — and the timeout branch would start configure-on-message rounds, up to an interview attempt, against a device that is not there anymore.

## Verified

Before/after run against the real module with stubs (11/11 assertions):
- master: the queued entry survives the leave, and the deleted-device run produces exactly the warning above;
- fixed: the leave clears the queue entry, the deleted-device run ends silently with a debug note and cleared bookkeeping;
- counter-checks: a live device with a genuine failure still warns, and the timeout/configure-on-message behaviour is unchanged.
- `npm run lint` and `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
