### PR TITLE
fix: unguarded coordinator lookup in doConfigure can escape as an unhandled rejection

### DIFF
--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -177,9 +177,13 @@ class DeviceConfigure extends BaseExtension {
     }
 
     async doConfigure(device, mappedDevice) {
-        const coordinatorEndpoint = await this.zigbee.getDevicesByType('Coordinator')[0].endpoints[0];
         const cfgKey = mappedDevice?.version ?? '0.0.0';
         try {
+            // getDevicesByType returns undefined on an internal error - do not
+            // dereference that (or an empty list) outside of the try
+            const coordinator = this.zigbee.getDevicesByType('Coordinator')?.[0];
+            if (!coordinator) return `Cannot configure '${this.devLabel(device.ieeeAddr, mappedDevice?.model)}': no coordinator available`;
+            const coordinatorEndpoint = coordinator.endpoints[0];
             if (mappedDevice) {
                 if (mappedDevice.configure === undefined) return `No configure available for '${this.devLabel(device.ieeeAddr, mappedDevice.model)}'.`;
                 if (cfgKey != device.meta.configured)


### PR DESCRIPTION
## What this protects against

`doConfigure` looked up the coordinator endpoint *outside* its `try` — and it is invoked fire-and-forget from three places (the 5-second queue worker, the priority push for a new device, the configure-on-message path). If that one line throws, the result is an unhandled promise rejection: under `compact` mode that class of error can take the whole process down.

And the line can throw in two documented ways: `getDevicesByType` returns `undefined` on an internal error by contract (`zigbeecontroller.js`, its catch ends in `return undefined`), and the device list can be empty while the network is being restarted from the admin (start with `reset` clears the herdsman database before the coordinator is re-created).

The strongest argument is the code itself: every other coordinator lookup in the tree is defensive — `onZigbeeStarted` here and in DelayedAction (inside their `try`), `resolveEntity` (inside its `try`, plus an `if (coordinator)` guard), `getCoordinatorIeee` (started-guard, `?? []`, length check). This was the only bare one.

## Fix

Move the lookup into the `try` and guard it explicitly: when no coordinator is available, return a clear message (`Cannot configure '<device>': no coordinator available`) instead of letting the generic error path produce the misleading `Failed to configure. --> Cannot read properties of undefined (reading '0')` — which names the end device although the problem is the coordinator. The admin's reconfigure dialog surfaces returned messages, so the user gets the real reason there too.

## Verified

Before/after run against the real module with stubs (9/9 assertions):
- master: both failure shapes (`undefined` return, empty list) escape as promise rejections — unhandled at all three real call sites;
- fixed: both are caught and produce the clear message; the normal path (coordinator present, configure succeeds, `meta.configured` written) is byte-identical in behaviour.
- `npm run lint` and `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
