### PR TITLE
fix: configure queue never runs again after the first reconnect

### DIFF
--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -252,6 +252,11 @@ class DeviceConfigure extends BaseExtension {
 
     async stop() {
         clearInterval(this.configureIntervall);
+        // reset like handleConfigureQueue does when the queue runs dry - a cleared
+        // handle is still truthy and would block PushDeviceToQueue from ever
+        // starting a new interval after a reconnect (the extensions are reused)
+        this.configureIntervall = null;
+        this.deviceConfigureQueue = [];
         this.configureOnMessageAttempts = {};
     }
 }


### PR DESCRIPTION
## What the user sees

After the first disconnect/reconnect of the coordinator (USB hiccup, network gateway restart), devices that need (re)configuration through the configure queue are silently never configured again — no error, no warning, they just stay unconfigured until the adapter itself is restarted.

## Why it happens

The controller and its extensions are created once in `onReady` and reused for the adapter's lifetime; the disconnect path only calls the extensions' `stop()` and later starts the same instances again. `DeviceConfigure.stop()` cleared the queue interval but kept the handle — and a cleared handle is still truthy. On the next start, `onZigbeeStarted` collects the devices that still need configuring and pushes them into the queue, but `PushDeviceToQueue`'s "interval already running" guard (`if (this.configureIntervall) return;`) sees the stale handle and never starts a new queue worker. The queue fills and is never drained.

`handleConfigureQueue` itself shows the intended pattern: when the queue runs dry it clears the interval **and** resets the handle to `null`. `stop()` only did the first half.

## Fix

Reset the handle to `null` in `stop()` — mirroring `handleConfigureQueue` — and drop the stale queue entries: the next `onZigbeeStarted` re-collects every device that still needs configuring anyway, so nothing is lost and nothing stale is kept.

## Verified

Before/after run against the real module with stubs (8/8 assertions), simulating connect → stop → reconnect:
- master: after `stop()`, the dead handle is still set; a device queued in the second connection phase never gets a queue worker (blocked by the stale handle);
- fixed: after `stop()` the handle is `null` and the queue empty; queuing a device in the second phase starts a fresh worker. First-phase behaviour identical.
- `npm run lint` and `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
