### PR TITLE
fix: device lifecycle — stop configuring/pinging departed devices, restore configure queue after reconnect

### DIFF
--- a/lib/zbDeviceAvailability.js
+++ b/lib/zbDeviceAvailability.js
@@ -188,6 +188,11 @@ class DeviceAvailability extends BaseExtension {
         delete this.timers[device.ieeeAddr];
     }
 
+    onDeviceLeave(data, entity) {
+        // stop the recurring availability check of a device that left the network
+        this.onDeviceRemove(entity?.device ?? data);
+    }
+
     async handleIntervalPingable(device, entity) {
         if (!this.isStarted) return;
         if (!this.active_ping) {

--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -27,7 +27,7 @@ class DeviceConfigure extends BaseExtension {
     async handleConfigureQueue() {
         if (this.deviceConfigureQueue.length < 1) {
             this.info('Handled all devices Queued for configuration.')
-            clearInterval(this.configureIntervall);
+            this.zigbee.adapter.clearInterval(this.configureIntervall);
             this.configureIntervall = null;
             return;
         }
@@ -58,7 +58,7 @@ class DeviceConfigure extends BaseExtension {
         else {
             this.deviceConfigureQueue.push({ id: device.ieeeAddr, dev:device, mapped:mappedDevice });
             if (this.configureIntervall) return;
-            this.configureIntervall = setInterval(async () => await this.handleConfigureQueue(), 5000);
+            this.configureIntervall = this.zigbee.adapter.setInterval(async () => await this.handleConfigureQueue(), 5000);
         }
     }
 
@@ -133,6 +133,8 @@ class DeviceConfigure extends BaseExtension {
             if (this.configureOnMessageAttempts && this.configureOnMessageAttempts.hasOwnProperty(device.ieeeAddr)) {
                 delete this.configureOnMessageAttempts[device.ieeeAddr];
             }
+            // drop the device from the configure queue - no point configuring one that has left
+            this.deviceConfigureQueue = this.deviceConfigureQueue.filter((item) => item.id !== device.ieeeAddr);
         } catch (error) {
             this.sendError(error);
             this.error(`Failed to DeviceConfigure.onDeviceRemove (${error && error.message ? error.message : 'no error message'})`);
@@ -251,7 +253,12 @@ class DeviceConfigure extends BaseExtension {
     }
 
     async stop() {
-        clearInterval(this.configureIntervall);
+        this.zigbee.adapter.clearInterval(this.configureIntervall);
+        // a cleared handle stays truthy, which would block PushDeviceToQueue from ever starting a
+        // new interval after a reconnect (the extension instance is reused) - reset it like
+        // handleConfigureQueue does when the queue runs dry. The queue itself is kept: devices
+        // still waiting to be configured keep their place across a reconnect.
+        this.configureIntervall = null;
         this.configureOnMessageAttempts = {};
     }
 }

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -1085,22 +1085,17 @@ class ZigbeeController extends EventEmitter {
     async handleDeviceLeave(message) {
         try {
             if (this.debugActive) this.debug('handleDeviceLeave', message);
-            const entity = await this.resolveEntity(message.device || message.ieeeAddr);
-            const friendlyName = entity ? entity.name : message.ieeeAddr;
-            const displayName = entity
-                ? utils.deviceDisplayName(entity.device?.ieeeAddr ?? message.ieeeAddr, this.adapter.stController.verifyDeviceName(entity.id, entity.mapped?.model, entity.mapped?.model))
-                : message.ieeeAddr;
-            if (this.adapter.stController.checkDebugDevice(friendlyName)) {
-                this.emit('device_debug', {ID: Date.now(), data: {flag:'dl', states:[{id: '--', value:'--', payload:message}], IO:true},message:`Device '${displayName}' has left the network`});
+            // zigbee-herdsman removes the device from its database before it emits deviceLeave,
+            // so resolveEntity() here can never succeed - it only produced a spurious
+            // 'resolve_entity failed' error on every leave. The device is gone; use its IEEE address.
+            if (this.adapter.stController.checkDebugDevice(message.ieeeAddr)) {
+                this.emit('device_debug', {ID: Date.now(), data: {flag:'dl', states:[{id: '--', value:'--', payload:message}], IO:true},message:`Device '${message.ieeeAddr}' has left the network`});
             }
             else
-                this.warn(`Device '${displayName}' left the network`);
-            this.emit('leave', message.ieeeAddr, entity?.mapped?.model);
+                this.warn(`Device '${message.ieeeAddr}' left the network`);
+            this.emit('leave', message.ieeeAddr);
             // Call extensions
-            this.callExtensionMethod(
-                'onDeviceLeave',
-                [message, entity],
-            );
+            this.callExtensionMethod('onDeviceLeave', [message, undefined]);
         } catch (error) {
             this.sendError(error);
             this.error(`Failed to handleDeviceLeave ${error && error.message ? error.message : 'no error message given'}`);


### PR DESCRIPTION
Bundles three related device-lifecycle fixes into one change, per your feedback on the split. They were previously submitted as separate PRs (#2962, #2963, #2966). #2964 and #2965 from the same batch I've closed — you were right on both: I traced them against the code, #2965 is not reachable (`stopHerdsman` is never called with the destroy flag, so the coordinator lookup can't escape as an unhandled rejection) and #2964 was cleanup without a functional effect.

All three below are triggered by a device leaving the network — in my case repeatedly, from an unstable Shelly BLU H&T sensor.

### 1. `handleDeviceLeave`: drop the entity lookup that always fails

zigbee-herdsman removes the device from its database *before* it emits `deviceLeave`, so `resolveEntity()` in `handleDeviceLeave` can never resolve it. It produced a spurious `resolve_entity failed` error on every single leave. Live from my log — the error is time-synchronous with each leave:

```
16:27:52.350  error: resolve_entity failed for {"kind":"ieee","key":"0x…fe4271dd","message":"success"} …
16:27:52.350  warn:  Device '0x…fe4271dd' left the network
16:28:15.724  error: resolve_entity failed for {"kind":"ieee","key":"0x…fe4271dd","message":"success"} …
16:28:15.725  warn:  Device '0x…fe4271dd' left the network
```

The device is gone, so the fix logs the IEEE address directly instead of resolving a name.

### 2. `DeviceAvailability`: stop pinging a device that left

A departed device kept its recurring availability check running. Added `onDeviceLeave` to clear the device's ping timer.

### 3. `DeviceConfigure`: configure queue dead after a reconnect

`stop()` cleared the interval but left the handle truthy, so after a reconnect `PushDeviceToQueue` returns early on the still-truthy handle and never starts a new interval — the configure queue stops running from the first reconnect on. `stop()` now resets the handle to `null` (the same reset `handleConfigureQueue` does when the queue drains) while **keeping** the queue, so devices still waiting keep their place. Also moved the interval to the adapter-managed `setInterval` (S5004 from #2961, matching what `DeviceAvailability` already does), and a departed device is dropped from the queue.

### Verification

Result of a local run of the combined path against the real extension classes — leave and reconnect injected as events, no hardware needed (throwaway script, not added to the test suite):

| check | result |
|---|---|
| push queues a device and starts the interval | ok |
| departed device dropped from the queue on remove | ok |
| `stop()` resets the interval handle to null **and keeps the queue** | ok |
| push after a reconnect starts a fresh interval (previously it did not) | ok |
| `onDeviceLeave` clears the availability timer of the departed device | ok |
| `handleDeviceLeave` no longer calls `resolveEntity` | ok |

Lint clean.
