### PR TITLE
fix: answer unsolicited genOta queryNextImageRequest with NO_IMAGE_AVAILABLE

### DIFF
--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -1502,7 +1502,7 @@ class StatesController extends EventEmitter {
                         }
         }
         
-                // raw message data for logging and msg_from_zigbee
+        // raw message data for logging and msg_from_zigbee
         const msgForState = Object.assign({}, message);
         delete msgForState['device'];
         delete msgForState['endpoint'];

--- a/lib/statescontroller.js
+++ b/lib/statescontroller.js
@@ -11,6 +11,7 @@ const zigbeeHerdsmanConvertersUtils = require('zigbee-herdsman-converters/lib/ut
 
 /// adapter defined functions and structures
 const utils = require('./utils');
+const { Zcl } = require('zigbee-herdsman');
 const { devLabel } = require('./deviceLabel');
 const modelDefinitions = require('./models');
 const safeJsonStringify = require('./json');
@@ -1486,7 +1487,22 @@ class StatesController extends EventEmitter {
             return;
         }
 
-        // raw message data for logging and msg_from_zigbee
+        if (type === 'commandQueryNextImageRequest' && device.type !== 'Coordinator') {
+                        try {
+                                            await message.endpoint.commandResponse(
+                                                                    'genOta',
+                                                                    'queryNextImageResponse',
+                                                { status: Zcl.Status.NO_IMAGE_AVAILABLE },
+                                                                    undefined,
+                                                                    message.meta.zclTransactionSequenceNumber,
+                                                                );
+                                            this.debug(`Answered unsolicited OTA query from '${this.devLabel(device.ieeeAddr, model)}' with NO_IMAGE_AVAILABLE`);
+                        } catch (error) {
+                                            this.error(`Failed to answer unsolicited OTA query from '${this.devLabel(device.ieeeAddr, model)}' (${error && error.message ? error.message : error})`);
+                        }
+        }
+        
+                // raw message data for logging and msg_from_zigbee
         const msgForState = Object.assign({}, message);
         delete msgForState['device'];
         delete msgForState['endpoint'];


### PR DESCRIPTION
### What
Adds handling for unsolicited `genOta` `queryNextImageRequest` events in `onZigbeeEvent`: answers with `NO_IMAGE_AVAILABLE` when a device asks about a firmware update on its own initiative.

### Why
`zigbee-herdsman` deliberately leaves this decision to the application layer (see [zigbee-herdsman#1823](https://github.com/Koenkk/zigbee-herdsman/pull/1823) and how Zigbee2MQTT handles it in its own [otaUpdate extension](https://github.com/Koenkk/zigbee2mqtt/blob/6835cbf5a73116aa4bfa097f2ad0dfb972018997/lib/extension/otaUpdate.ts#L181-L188)). Without an answer, some devices keep sending `queryNextImageRequest` on a short interval indefinitely, since they never get any reply at all - observed in practice as a request roughly every 3 seconds from a mains-powered router (SONOFF MINI-ZBRBS).

### Tested
- `node --check` on the modified file
- `npm run test:package` (56/56 passing)
- `eslint` clean
- Applied locally against a live network and confirmed the previously constant ~3s polling from the affected device stops after the first reply.