### PR TITLE
Two small fixes: OTA update-check guard (undefined definition) + permitJoin countdown reset on close

### DIFF
--- a/lib/ota.js
+++ b/lib/ota.js
@@ -284,7 +284,7 @@ class Ota {
         try {
             this.debug(`Checking if firmware update is available for '${devLabel(this.adapter, ieeeAddr, entity?.mapped?.model)}'`);
 
-            if (entity && entity.mapped.ota) {
+            if (entity?.mapped?.ota) {
                 const available = await entity.device.checkOta({ downgrade:false }, undefined, typeof entity.mapped.ota === 'object' ? entity.mapped.ota : {}, undefined);
                 result.status = available.available ? 'available' : 'not_available';
                 if (available.currentFileVersion !== available.otaFileVersion) {

--- a/lib/zigbeecontroller.js
+++ b/lib/zigbeecontroller.js
@@ -993,6 +993,7 @@ class ZigbeeController extends EventEmitter {
                 this.emit('pairing', `Closed network${timestr}`, 0);
                 clearInterval(this._permitJoinInterval);
                 this._permitJoinInterval = null;
+                this._permitJoinTime = 0;
             }
         }
         catch (error) {


### PR DESCRIPTION
Two small, independent fixes, each triggered by a real event on a production `ember` coordinator (EmberZNet 8.0.2). Both are one-line changes; `eslint` passes. No test scenarios added (small changes) — the production logs below are the "seen it happen".

They surfaced on the same instance but are unrelated (different subsystems) — happy to split into two PRs if you'd rather.

---

### 1. `fix(pairing)` — permitJoin countdown not reset on close

**Symptom** (same session, ~16 min apart):
```
16:08:06 info: Opening network.
16:08:06 info: Opened zigbee Network for 60 seconds
16:09:06 info: Closed Zigbee network with 1 second remaining.
16:25:06 info: Extending open network.        <-- network had closed 16 min earlier
16:25:07 info: Opened zigbee Network for 60 seconds
```
Opening the network a second time logs **"Extending open network"** although the previous window had already timed out and closed — the adapter still considers a pairing window active long after the radio closed.

**Cause:** in `handlePermitJoinChanged`, the timeout-close branch clears the countdown interval but never resets `_permitJoinTime` (it is left at ~1 — the value shown in "1 second remaining"). `permitJoin()` then treats `_permitJoinTime > 0` as an already-open window and logs "Extending …" instead of "Opening …". The manual stop path (`permitJoin(0)`) already resets it; only the timeout path did not.

**Fix:** reset `_permitJoinTime = 0` when the network closes.

---

### 2. `fix(ota)` — update-availability check throws for devices without a definition

**Symptom** (repeats every OTA cycle for un-interviewed devices):
```
warn: Failed to check if update available for 'unnamed (0xb4e3f9fffe56ebc8)' Cannot read properties of undefined (reading 'ota')
warn: Failed to check if update available for 'unnamed (0x0c4314fffe0ed00e)' Cannot read properties of undefined (reading 'ota')
```
A device that never completed interview has no resolved definition (`entity.mapped` is undefined). `lib/ota.js` accessed `entity.mapped.ota` directly, so the check throws and is logged as a misleading "Failed to check if update available" warning.

**Cause / consistency:** that line was the only `entity.mapped.*` access in the function not using optional chaining — the four adjacent accesses already use `entity?.mapped?.model`.

**Fix:** `entity?.mapped?.ota`. Such devices now take the existing `not_supported` branch (which already logs a clean debug line with the id), and the `warn` is reserved for genuine check failures (device didn't respond).

---

Found on `ember`; neither change is stack-specific (both are adapter-side JS).