### PR TITLE
fix: DeviceConfigure: do not read the definition before the guard

### DIFF
--- a/lib/zbDeviceConfigure.js
+++ b/lib/zbDeviceConfigure.js
@@ -63,13 +63,13 @@ class DeviceConfigure extends BaseExtension {
     }
 
     shouldConfigure(device, mappedDevice) {
-        const definitionVersion = mappedDevice.version || '0.0.0';
         if (!device || !mappedDevice) {
             return false;
         }
         if (!mappedDevice || !mappedDevice.configure) {
             return false;
         }
+        const definitionVersion = mappedDevice.version || '0.0.0';
         // no configuration if we are interviewing or configuring
         if (this.configuring.has(device.ieeeAddr) || device.interviewing) return false;
         const t = Date.now();


### PR DESCRIPTION
## What happens

`shouldConfigure()` reads the definition one line **before** the guard that checks whether it exists:

```js
shouldConfigure(device, mappedDevice) {
    const definitionVersion = mappedDevice.version || '0.0.0';   // <-- reads first
    if (!device || !mappedDevice) {                              // <-- checks after
        return false;
    }
```

For a device that has no definition — `findByDevice()` returns `undefined` — the read throws. The exception leaves `shouldConfigure()`, lands in the `try/catch` **around the whole loop** in `onZigbeeStarted()`, and the loop stops. Every device after the first unmapped one is then never checked for a pending re-configuration, so a definition that bumped its `version` never takes effect until the device is re-paired.

## Seen it happen

On my production system (3.5.5, ember/SLZB-MR3, 60 devices) three entries are left over without a model. Every adapter start:

```
Unknown resoveEntity0x0c4314fffe0ed00e: Resolve Entity did not manage to find a mapped device …
Unknown resoveEntity0xb4e3f9fffe56ebc8: …
Unknown resoveEntity0x70c59cfffe2c43f5: …
DeviceConfigure:Failed to DeviceConfigure.onZigbeeStarted (Cannot read properties of undefined (reading 'version'))
```

The last line is this defect, and it is the reason the start-up re-configuration check does nothing on that installation.

## The change

Move the assignment below the two guards that are already there. Nothing else — the guards, the fallback and the rest of the function stay as they are.

Verified directly against the class: with an unmapped device, `shouldConfigure()` throws `Cannot read properties of undefined (reading 'version')` before the change and returns `false` after it. `npm run lint` reports no new findings (the three pre-existing warnings in `admin/admin.js` are untouched).

## One thing I deliberately did not change

A throw inside the loop still aborts the remaining devices, because the `try/catch` sits around the whole loop in `onZigbeeStarted()`. Guarding each iteration would make the start-up robust against future errors of this kind, but I have no second case where it actually happens — happy to add it if you want it.